### PR TITLE
feat: add Claude proxy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # プロジェクト概要
 
-このリポジトリは、メンタライズ学習支援用のチャット UI と、OpenAI API へのプロキシエンドポイントを提供します。
+このリポジトリは、メンタライズ学習支援用のチャット UI と、OpenAI / Claude API へのプロキシエンドポイントを提供します。
 
 ## エンドポイント構成
 
@@ -8,13 +8,27 @@
   - フロントエンドが標準的に利用するエンドポイントです。
   - アシスタントの応答品質を安定させるために presence/frequency penalty の既定値を付与します。
   - 本番利用を想定し、サーバー内部の詳細なエラー文言はユーザーに返さない設計です。
+- `/api/claude-proxy`
+  - Anthropic Claude モデルをサーバー経由で呼び出すための新しいエンドポイントです。
+  - OpenAI ルートと同じ正規化ロジックを使いつつ、`https://api.anthropic.com/v1/messages` へ転送するよう調整しています。
+  - レートリミットや認証エラーなど、Anthropic 固有のエラーコードを日本語メッセージに変換します。
 - `/api/chat`
   - 過去のフロントエンド実装との後方互換性を保つために残しているレガシーエンドポイントです。
   - 実装そのものは `/api/openai-proxy` と共通化されており、追加のオプションを与えないラッパーに留めています。
   - 旧クライアントでも挙動の違いが生じないよう、詳細なエラー文言を返す設定にしています。
 
-どちらのエンドポイントも内部的には `_openaiProxyHandler.js` で定義された共通ハンドラを呼び出し、
-`_messageUtils.js` でメッセージ履歴を正規化してから OpenAI API へ転送します。
+OpenAI 用ルートは `_openaiProxyHandler.js`、Claude 用ルートは `_anthropicProxyHandler.js` を介して、
+`_messageUtils.js` でメッセージ履歴を正規化してから各プロバイダーの API へ転送します。
+
+### 「サーバー側」の意味と Claude 連携
+
+- `api/` フォルダの各ファイルは、Next.js や Vercel Edge Functions のような「サーバー側で動作する API ルート」に相当します。
+  ブラウザから直接 OpenAI に鍵を付けてアクセスさせるのではなく、一度これらのエンドポイントに POST してから、サーバーが OpenAI へ代理で通信します。
+- 現在は OpenAI / Claude の双方をサーバー経由で利用できます。`api/openai-proxy.js` は OpenAI 専用、`api/claude-proxy.js` は Claude 専用のラッパーです。
+- どちらも内部で `_messageUtils.js` による正規化を行った後、`_openaiProxyHandler.js` / `_anthropicProxyHandler.js` が API 固有のヘッダーやレスポンス整形を担当します。
+- Supabase を利用している場合でも、API ルートの配置は変わりません。Supabase には保存された設定（API キーやモデル名など）を保管し、フロントエンドから取得してリクエストに含めます。サーバー側で目的のプロバイダーへ転送する部分だけを差し替えれば、OpenAI と同様のフローで安全に Claude を呼び出せます。
+
+> 参考: フロントエンドから直接 Claude API を呼び出す構成にしている場合は、新しいサーバーエンドポイントを作らなくても利用可能です。ただしブラウザに API キーが露出するため、保護が必要な環境ではサーバー経由のプロキシを推奨します。
 
 ## 会話履歴の正規化が必要な理由
 
@@ -35,8 +49,10 @@
 
 ```
 api/
+  |_ _anthropicProxyHandler.js # Claude (Anthropic) 向けリクエスト組み立て＆レスポンス処理
   |_ _messageUtils.js       # リクエスト正規化・APIキー抽出などの共通ユーティリティ
   |_ _openaiProxyHandler.js # OpenAI へのリクエスト組み立て＆レスポンス処理を担う共通ハンドラ
+  |_ claude-proxy.js        # Claude 用 `/api/claude-proxy` エンドポイント定義
   |_ chat.js                # レガシー `/api/chat` 向け薄いラッパー
   |_ openai-proxy.js        # メインの `/api/openai-proxy` エンドポイント定義
 index.html                  # フロントエンド

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -1,0 +1,320 @@
+import {
+  prepareConversationPayload,
+  resolveApiKey,
+  toNumber,
+} from './_messageUtils.js';
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+}
+
+function mergeSystemPrompts(systemMessages) {
+  return systemMessages
+    .map(message => message.content?.trim())
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function toAnthropicContentBlock(text) {
+  return [{ type: 'text', text }];
+}
+
+function normalizeConversation(messages) {
+  const systemMessages = [];
+  const conversation = [];
+
+  for (const message of messages) {
+    if (!message || typeof message.content !== 'string') continue;
+
+    const trimmed = message.content.trim();
+    if (!trimmed) continue;
+
+    if (message.role === 'system') {
+      systemMessages.push({ ...message, content: trimmed });
+      continue;
+    }
+
+    const role = message.role === 'assistant' ? 'assistant' : 'user';
+
+    const lastTurn = conversation[conversation.length - 1];
+    if (lastTurn && lastTurn.role === role) {
+      lastTurn.content[0].text += `\n${trimmed}`;
+    } else {
+      conversation.push({
+        role,
+        content: toAnthropicContentBlock(trimmed),
+      });
+    }
+  }
+
+  while (conversation.length && conversation[0].role !== 'user') {
+    conversation.shift();
+  }
+
+  const hasUserTurn = conversation.some(turn => turn.role === 'user');
+  if (!hasUserTurn) {
+    throw new Error('Anthropic に渡す会話履歴にユーザーの発話が含まれていません');
+  }
+
+  return {
+    systemPrompt: mergeSystemPrompts(systemMessages),
+    conversation,
+  };
+}
+
+function buildRequestPayload(body, normalizedMessages, options) {
+  const {
+    defaultModel,
+    defaultTemperature,
+    defaultMaxTokens,
+    defaultTopP,
+  } = options;
+
+  const { systemPrompt, conversation } = normalizeConversation(normalizedMessages);
+
+  const model = typeof body.model === 'string' && body.model.trim()
+    ? body.model.trim()
+    : defaultModel;
+
+  const payload = {
+    model,
+    messages: conversation,
+    max_tokens: toNumber(
+      body.max_tokens ?? body.maxTokens ?? body.max_output_tokens ?? body.maxOutputTokens,
+      defaultMaxTokens,
+    ),
+  };
+
+  if (payload.max_tokens == null) {
+    payload.max_tokens = defaultMaxTokens;
+  }
+
+  const temperature = toNumber(body.temperature, defaultTemperature);
+  if (temperature != null) {
+    payload.temperature = temperature;
+  }
+
+  const topP = toNumber(body.top_p ?? body.topP, defaultTopP);
+  if (topP != null) {
+    payload.top_p = topP;
+  }
+
+  const stopSequences = body.stop_sequences ?? body.stopSequences;
+  if (Array.isArray(stopSequences) && stopSequences.length) {
+    payload.stop_sequences = stopSequences
+      .map(value => (typeof value === 'string' ? value : ''))
+      .filter(Boolean);
+  }
+
+  if (systemPrompt) {
+    payload.system = systemPrompt;
+  }
+
+  return payload;
+}
+
+function buildErrorResponse(options, details) {
+  const { internalErrorMessage, exposeErrorDetails } = options;
+  const payload = { error: internalErrorMessage };
+
+  if (details && (exposeErrorDetails || process.env.NODE_ENV === 'development')) {
+    payload.details = details;
+  }
+
+  return payload;
+}
+
+async function forwardToAnthropic(apiKey, payload, options) {
+  const response = await fetch(options.apiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': options.anthropicVersion,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  let data = null;
+  try {
+    data = await response.json();
+  } catch (error) {
+    console.error('Failed to parse Anthropic response JSON:', error);
+  }
+
+  return { response, data };
+}
+
+function normalizeAnthropicResponse(data, requestPayload) {
+  if (!data) return null;
+
+  const content = Array.isArray(data.content) ? data.content : [];
+  const text = content
+    .map(part => {
+      if (!part) return '';
+      if (typeof part.text === 'string') return part.text;
+      if (Array.isArray(part.content)) {
+        return part.content
+          .map(inner => (typeof inner?.text === 'string' ? inner.text : ''))
+          .filter(Boolean)
+          .join('\n');
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+
+  if (!text) {
+    return null;
+  }
+
+  return {
+    response: text,
+    model: data.model ?? requestPayload.model,
+    usage: data.usage,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function handleAnthropicError(res, status, data, options) {
+  console.error('Anthropic API Error:', data);
+
+  if (data?.error) {
+    const { type, message } = data.error;
+    const safeMessage = typeof message === 'string' ? message : '';
+
+    switch (type) {
+      case 'authentication_error':
+        return res.status(401).json({ error: 'Anthropic APIキーが無効です。' });
+      case 'permission_error':
+        return res
+          .status(403)
+          .json({ error: 'Anthropic APIキーに必要な権限がありません。' });
+      case 'rate_limit_error':
+        return res
+          .status(429)
+          .json({
+            error:
+              'Anthropic APIのレート制限に達しました。しばらく待ってから再試行してください。',
+          });
+      case 'invalid_request_error':
+        return res.status(status || 400).json({
+          error: safeMessage
+            ? `リクエストが無効です: ${safeMessage}`
+            : 'Anthropic APIへのリクエスト内容が無効です。入力値を確認してください。',
+        });
+      case 'not_found_error':
+        return res.status(404).json({
+          error: '指定されたリソースが見つかりません。モデル名やエンドポイントを確認してください。',
+        });
+      default:
+        return res
+          .status(status || 502)
+          .json(
+            buildErrorResponse(options, safeMessage || `Unexpected error type: ${type}`),
+          );
+    }
+  }
+
+  return res.status(status || 500).json(buildErrorResponse(options));
+}
+
+export function createAnthropicProxyHandler(options = {}) {
+  const handlerOptions = {
+    apiUrl: 'https://api.anthropic.com/v1/messages',
+    anthropicVersion: '2023-06-01',
+    defaultModel: 'claude-3-haiku-20240307',
+    defaultTemperature: 0.7,
+    defaultMaxTokens: 1024,
+    defaultTopP: undefined,
+    internalErrorMessage: 'サーバー内部エラーが発生しました',
+    exposeErrorDetails: false,
+    ...options,
+  };
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method not allowed' });
+    }
+
+    let normalized;
+    try {
+      normalized = prepareConversationPayload(req.body);
+    } catch (error) {
+      console.error('Request normalization failed:', error);
+      return res.status(400).json({
+        error: error.message || 'リクエスト形式が正しくありません',
+      });
+    }
+
+    const body = normalized.body;
+    const apiKeyCandidate = resolveApiKey(req.headers, body);
+    const fallbackKey =
+      typeof body.anthropicApiKey === 'string' ? body.anthropicApiKey.trim() : '';
+    const apiKey = apiKeyCandidate || fallbackKey;
+
+    if (!apiKey) {
+      return res.status(400).json({ error: 'Anthropic APIキーが指定されていません' });
+    }
+
+    if (body.stream === true) {
+      return res.status(400).json({ error: 'ストリーミングレスポンスには対応していません。' });
+    }
+
+    let requestPayload;
+    try {
+      requestPayload = buildRequestPayload(body, normalized.messages, handlerOptions);
+    } catch (error) {
+      console.error('Failed to build Anthropic payload:', error);
+      return res.status(400).json({
+        error: error.message || 'Anthropic 向けリクエストの組み立てに失敗しました',
+      });
+    }
+
+    try {
+      console.log('Making request to Anthropic with model:', requestPayload.model);
+
+      const { response, data } = await forwardToAnthropic(
+        apiKey,
+        requestPayload,
+        handlerOptions,
+      );
+
+      console.log('Anthropic response status:', response.status);
+
+      if (!response.ok) {
+        return handleAnthropicError(res, response.status, data, handlerOptions);
+      }
+
+      const normalizedResponse = normalizeAnthropicResponse(data, requestPayload);
+      if (normalizedResponse) {
+        return res.json(normalizedResponse);
+      }
+
+      console.error('Unexpected Anthropic response structure:', data);
+      return res.status(500).json({
+        error: 'Claude からの応答が空または不正な形式です',
+      });
+    } catch (error) {
+      console.error('Anthropic Proxy Handler Error:', error);
+
+      if (error.name === 'TypeError' && error.message.includes('fetch')) {
+        return res.status(503).json({
+          error:
+            'Anthropic APIへの接続に失敗しました。しばらく待ってから再試行してください。',
+        });
+      }
+
+      return res.status(500).json(buildErrorResponse(handlerOptions, error.message));
+    }
+  };
+}

--- a/api/claude-proxy.js
+++ b/api/claude-proxy.js
@@ -1,0 +1,14 @@
+import { createAnthropicProxyHandler } from './_anthropicProxyHandler.js';
+
+/**
+ * `/api/claude-proxy` は Anthropic Claude モデルへの呼び出しをサーバー経由で仲介します。
+ * OpenAI プロキシと同様に `_messageUtils` を用いて履歴を正規化し、Anthropic API の仕様に合わせた
+ * リクエストへ変換したうえで `https://api.anthropic.com/v1/messages` へ転送します。
+ */
+export default createAnthropicProxyHandler({
+  defaultModel: 'claude-3-haiku-20240307',
+  defaultTemperature: 0.6,
+  defaultMaxTokens: 1024,
+  internalErrorMessage:
+    'サーバー内部エラーが発生しました。管理者に連絡してください。',
+});

--- a/index.html
+++ b/index.html
@@ -3332,26 +3332,22 @@ function sanitizeAIText(raw) {
 
                 } else if (adminConfig.apiProvider === 'claude') {
                     const maxTokens = Math.max(adminConfig.maxTokens || 1024, 1);
-                    apiUrl = 'https://api.anthropic.com/v1/messages';
+                    apiUrl = '/api/claude-proxy';
                     headers = {
                         'Content-Type': 'application/json',
-                        'x-api-key': adminConfig.apiKey,
-                        'anthropic-version': '2023-06-01'
+                        'Authorization': `Bearer ${adminConfig.apiKey}`
                     };
 
-                    const messages = [];
-                    historyForApi.forEach(msg => {
-                        messages.push({
-                            role: msg.role,
-                            content: msg.content
-                        });
-                    });
+                    const messages = historyForApi.map(msg => ({
+                        role: msg.role,
+                        content: msg.content
+                    }));
 
                     requestBody = {
                         model: adminConfig.model,
                         max_tokens: maxTokens,
                         temperature: adminConfig.temperature ?? 0.7,
-                        system: systemPrompt,
+                        systemPrompt,
                         messages
                     };
                 } else if (adminConfig.apiProvider === 'gemini') {
@@ -3424,20 +3420,25 @@ function sanitizeAIText(raw) {
                     let rawText = '';
 
                     if (adminConfig.apiProvider === 'claude') {
-                        if (!Array.isArray(data?.content)) {
-                            console.error('Invalid Claude response:', data);
-                            throw new Error('Claude APIから無効なレスポンス形式が返されました');
+                        const normalizedText = typeof data?.response === 'string'
+                            ? data.response.trim()
+                            : '';
+
+                        if (normalizedText) {
+                            rawText = normalizedText;
+                        } else if (Array.isArray(data?.content)) {
+                            const textBlocks = data.content
+                                .filter(block => block?.type === 'text' && typeof block.text === 'string')
+                                .map(block => block.text);
+
+                            if (textBlocks.length) {
+                                rawText = textBlocks.join('\n');
+                            }
                         }
 
-                        const textBlocks = data.content
-                            .filter(block => block?.type === 'text' && typeof block.text === 'string')
-                            .map(block => block.text);
-
-                        if (!textBlocks.length) {
-                            console.warn('Claude response has no text content:', data);
+                        if (!rawText) {
+                            console.warn('Claude response did not contain text output:', data);
                             rawText = '(応答にテキストが含まれていませんでした)';
-                        } else {
-                            rawText = textBlocks.join('\n');
                         }
 
                     } else if (adminConfig.apiProvider === 'gemini') {
@@ -3506,7 +3507,10 @@ function sanitizeAIText(raw) {
                     let errorMsg = 'APIリクエストが失敗しました';
 
                     if (adminConfig.apiProvider === 'claude') {
-                        errorMsg = parsedError?.error?.message || errorMsg;
+                        const proxyMessage = typeof parsedError?.error === 'string'
+                            ? parsedError.error
+                            : parsedError?.error?.message;
+                        errorMsg = proxyMessage || errorMsg;
 
                         if (response.status === 401) {
                             errorMsg += ' - APIキーが無効です';


### PR DESCRIPTION
## Summary
- add an Anthropic-specific proxy handler and `/api/claude-proxy` entry for server-side Claude calls
- document the new Claude support alongside existing OpenAI routes in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ecbf2751b4832bbd7571fd3bea47b2