### PR TITLE
Handle structured AI state in frontend

### DIFF
--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -91,7 +91,8 @@ function normalizeConversation(messages, stateMessageContent) {
   };
 }
 
-// Claudeはsystemに最大4ブロックまでcache_controlを付けられるため、超過分は後ろ側をマージする。
+// Claudeは "system" メッセージに対してのみ cache_control を最大4ブロックまで付けられるため、
+// それ以外（user/assistant）のターンはここでは扱わない。超過分は後ろ側をマージする。
 // isStateフラグはマージ後のブロックにもORで引き継ぎ、"この塊は動的stateを含む"という判定を維持する。
 function limitCacheBreakpoints(blocks, maxBreakpoints = 4) {
   const limited = blocks.map(block => ({ ...block }));

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -44,6 +44,8 @@ function toAnthropicContentBlock(text) {
 
 // Systemメッセージ群とユーザー/assistantターンを分離し、stateを含むsystemメッセージにフラグを付与する。
 // stateMessageContent は prepareConversationPayload が生成する「Stateを埋め込んだsystemテキスト」そのもの。
+// 3パート構成（ベースのsystemプロンプト + 構造化出力指示 + stateメッセージ）が分かっているので、
+// 連続する静的systemメッセージは一塊にまとめ、state付きのsystemメッセージは単独ブロックとして保持する。
 function normalizeConversation(messages, stateMessageContent) {
   const systemMessages = [];
   const conversation = [];
@@ -85,8 +87,19 @@ function normalizeConversation(messages, stateMessageContent) {
     throw new Error('Anthropic に渡す会話履歴にユーザーの発話が含まれていません');
   }
 
+  const groupedSystemBlocks = [];
+  for (const block of systemMessages) {
+    const last = groupedSystemBlocks[groupedSystemBlocks.length - 1];
+    if (last && !last.isState && !block.isState) {
+      last.text = [last.text, block.text].filter(Boolean).join('\n\n');
+      continue;
+    }
+
+    groupedSystemBlocks.push({ ...block });
+  }
+
   return {
-    systemBlocks: systemMessages,
+    systemBlocks: groupedSystemBlocks,
     conversation,
   };
 }

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -38,18 +38,11 @@ function setCorsHeaders(res) {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 }
 
-function mergeSystemPrompts(systemMessages) {
-  return systemMessages
-    .map(message => message.content?.trim())
-    .filter(Boolean)
-    .join('\n\n');
-}
-
 function toAnthropicContentBlock(text) {
   return [{ type: 'text', text }];
 }
 
-function normalizeConversation(messages) {
+function normalizeConversation(messages, stateMessageContent) {
   const systemMessages = [];
   const conversation = [];
 
@@ -60,7 +53,10 @@ function normalizeConversation(messages) {
     if (!trimmed) continue;
 
     if (message.role === 'system') {
-      systemMessages.push({ ...message, content: trimmed });
+      systemMessages.push({
+        text: trimmed,
+        isState: !!stateMessageContent && trimmed === stateMessageContent,
+      });
       continue;
     }
 
@@ -87,9 +83,43 @@ function normalizeConversation(messages) {
   }
 
   return {
-    systemPrompt: mergeSystemPrompts(systemMessages),
+    systemBlocks: systemMessages,
     conversation,
   };
+}
+
+function limitCacheBreakpoints(blocks, maxBreakpoints = 4) {
+  const limited = blocks.map(block => ({ ...block }));
+
+  while (limited.length > maxBreakpoints) {
+    const overflow = limited.splice(maxBreakpoints - 1);
+    const mergedText = overflow.map(part => part.text).filter(Boolean).join('\n\n');
+    limited[maxBreakpoints - 1].text = [
+      limited[maxBreakpoints - 1].text,
+      mergedText,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+    limited[maxBreakpoints - 1].isState =
+      limited[maxBreakpoints - 1].isState || overflow.some(part => part.isState);
+  }
+
+  return limited;
+}
+
+function buildSystemField(systemBlocks, cacheType) {
+  if (!systemBlocks.length) return null;
+
+  if (cacheType) {
+    const limitedBlocks = limitCacheBreakpoints(systemBlocks);
+    return limitedBlocks.map(block => ({
+      type: 'text',
+      text: block.text,
+      cache_control: { type: cacheType },
+    }));
+  }
+
+  return systemBlocks.map(block => block.text).filter(Boolean).join('\n\n');
 }
 
 function buildRequestPayload(body, normalized, options) {
@@ -102,7 +132,10 @@ function buildRequestPayload(body, normalized, options) {
     defaultTopK,
   } = options;
 
-  const { systemPrompt, conversation } = normalizeConversation(normalizedMessages);
+  const { systemBlocks, conversation } = normalizeConversation(
+    normalizedMessages,
+    normalized.stateMessageContent,
+  );
 
   const model = typeof body.model === 'string' && body.model.trim()
     ? body.model.trim()
@@ -162,21 +195,15 @@ function buildRequestPayload(body, normalized, options) {
     payload.thinking = { type: 'enabled', budget_tokens: thinkingBudget };
   }
 
-  if (systemPrompt) {
-    const cacheControl = body.system_cache_control ?? body.systemCacheControl;
-    const cacheType = typeof cacheControl?.type === 'string'
-      ? cacheControl.type.trim()
-      : null;
-    if (cacheType) {
-      payload.system = [
-        {
-          type: 'text',
-          text: systemPrompt,
-          cache_control: { type: cacheType },
-        },
-      ];
-    } else {
-      payload.system = systemPrompt;
+  const cacheControl = body.system_cache_control ?? body.systemCacheControl;
+  const cacheType = typeof cacheControl?.type === 'string'
+    ? cacheControl.type.trim()
+    : null;
+
+  if (systemBlocks.length) {
+    const systemField = buildSystemField(systemBlocks, cacheType);
+    if (systemField) {
+      payload.system = systemField;
     }
   }
 

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -131,6 +131,10 @@ function buildSystemField(systemBlocks, cacheType) {
 
   if (cacheType) {
     const limitedBlocks = limitCacheBreakpoints(systemBlocks);
+    // cache_control は system ブロックにのみ付与される。ここで静的ブロックと
+    // state を含む動的ブロックの両方へ同一設定を付けることで、静的部のみ一致
+    // している場合でもキャッシュが再利用される（state 部分が変わればその
+    // ブロックだけが無効化される）。
     return limitedBlocks.map(block => ({
       type: 'text',
       text: block.text,

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -143,16 +143,41 @@ function buildRequestPayload(body, normalized, options) {
       .filter(Boolean);
   }
 
+  const thinkingModeRaw = body.thinking_mode ?? body.thinkingMode;
+  const thinkingMode = typeof thinkingModeRaw === 'string'
+    ? thinkingModeRaw.trim()
+    : null;
   const thinkingBudget = toNumber(
     body.thinking_budget_tokens ?? body.thinkingBudgetTokens,
     null,
   );
-  if (thinkingBudget != null) {
+  if (thinkingMode === 'enabled') {
+    payload.thinking = { type: 'enabled' };
+    if (thinkingBudget != null) {
+      payload.thinking.budget_tokens = thinkingBudget;
+    }
+  } else if (thinkingMode === 'disabled') {
+    payload.thinking = { type: 'disabled' };
+  } else if (thinkingBudget != null) {
     payload.thinking = { type: 'enabled', budget_tokens: thinkingBudget };
   }
 
   if (systemPrompt) {
-    payload.system = systemPrompt;
+    const cacheControl = body.system_cache_control ?? body.systemCacheControl;
+    const cacheType = typeof cacheControl?.type === 'string'
+      ? cacheControl.type.trim()
+      : null;
+    if (cacheType) {
+      payload.system = [
+        {
+          type: 'text',
+          text: systemPrompt,
+          cache_control: { type: cacheType },
+        },
+      ];
+    } else {
+      payload.system = systemPrompt;
+    }
   }
 
   const explicitTools = Array.isArray(body.tools) ? body.tools : null;

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -99,6 +99,7 @@ function buildRequestPayload(body, normalized, options) {
     defaultTemperature,
     defaultMaxTokens,
     defaultTopP,
+    defaultTopK,
   } = options;
 
   const { systemPrompt, conversation } = normalizeConversation(normalizedMessages);
@@ -130,11 +131,24 @@ function buildRequestPayload(body, normalized, options) {
     payload.top_p = topP;
   }
 
+  const topK = toNumber(body.top_k ?? body.topK, defaultTopK);
+  if (topK != null) {
+    payload.top_k = topK;
+  }
+
   const stopSequences = body.stop_sequences ?? body.stopSequences;
   if (Array.isArray(stopSequences) && stopSequences.length) {
     payload.stop_sequences = stopSequences
       .map(value => (typeof value === 'string' ? value : ''))
       .filter(Boolean);
+  }
+
+  const thinkingBudget = toNumber(
+    body.thinking_budget_tokens ?? body.thinkingBudgetTokens,
+    null,
+  );
+  if (thinkingBudget != null) {
+    payload.thinking = { type: 'enabled', budget_tokens: thinkingBudget };
   }
 
   if (systemPrompt) {
@@ -370,6 +384,7 @@ export function createAnthropicProxyHandler(options = {}) {
     defaultTemperature: 0.7,
     defaultMaxTokens: 1024,
     defaultTopP: undefined,
+    defaultTopK: undefined,
     internalErrorMessage: 'サーバー内部エラーが発生しました',
     exposeErrorDetails: false,
     ...options,

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -4,6 +4,34 @@ import {
   toNumber,
 } from './_messageUtils.js';
 
+const DEFAULT_STATE_TOOL = {
+  name: 'state_update',
+  description:
+    'ユーザーへの返信文(reply)と更新後のstate(JSON)を含む構造化出力を返すためのツールです。',
+  input_schema: {
+    type: 'object',
+    properties: {
+      reply: {
+        type: 'string',
+        description: 'ユーザーに送る受容文と質問文を統合したメッセージ。',
+      },
+      state: {
+        description: '更新後のState全体。',
+        oneOf: [
+          { type: 'object', additionalProperties: true },
+          { type: 'null' },
+        ],
+      },
+    },
+    required: ['reply', 'state'],
+    additionalProperties: false,
+  },
+};
+
+function createDefaultStateTool() {
+  return JSON.parse(JSON.stringify(DEFAULT_STATE_TOOL));
+}
+
 function setCorsHeaders(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
@@ -64,7 +92,8 @@ function normalizeConversation(messages) {
   };
 }
 
-function buildRequestPayload(body, normalizedMessages, options) {
+function buildRequestPayload(body, normalized, options) {
+  const normalizedMessages = normalized.messages;
   const {
     defaultModel,
     defaultTemperature,
@@ -112,6 +141,20 @@ function buildRequestPayload(body, normalizedMessages, options) {
     payload.system = systemPrompt;
   }
 
+  const explicitTools = Array.isArray(body.tools) ? body.tools : null;
+  if (explicitTools && explicitTools.length) {
+    payload.tools = explicitTools;
+  } else if (normalized.expectsStructuredResponse) {
+    payload.tools = [createDefaultStateTool()];
+  }
+
+  const toolChoice = body.tool_choice ?? body.toolChoice;
+  if (toolChoice != null) {
+    payload.tool_choice = toolChoice;
+  } else if (payload.tools && payload.tools.length === 1 && normalized.expectsStructuredResponse) {
+    payload.tool_choice = { type: 'tool', name: payload.tools[0].name };
+  }
+
   return payload;
 }
 
@@ -151,32 +194,129 @@ function normalizeAnthropicResponse(data, requestPayload) {
   if (!data) return null;
 
   const content = Array.isArray(data.content) ? data.content : [];
-  const text = content
-    .map(part => {
-      if (!part) return '';
-      if (typeof part.text === 'string') return part.text;
-      if (Array.isArray(part.content)) {
-        return part.content
-          .map(inner => (typeof inner?.text === 'string' ? inner.text : ''))
-          .filter(Boolean)
-          .join('\n');
-      }
-      return '';
-    })
-    .filter(Boolean)
-    .join('\n')
-    .trim();
 
-  if (!text) {
+  let textResponse = '';
+  let structuredReply = null;
+  let structuredState = null;
+
+  for (const part of content) {
+    if (!part) continue;
+
+    if (part.type === 'tool_use' && part.input && structuredReply == null) {
+      const input = part.input;
+      if (typeof input.reply === 'string') {
+        structuredReply = input.reply;
+      }
+      if (input.state !== undefined) {
+        structuredState = normalizeState(input.state);
+      }
+      continue;
+    }
+
+    if (typeof part.text === 'string' && part.text.trim()) {
+      textResponse += (textResponse ? '\n' : '') + part.text.trim();
+    } else if (Array.isArray(part.content)) {
+      const nestedText = part.content
+        .map(inner => (typeof inner?.text === 'string' ? inner.text : ''))
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+      if (nestedText) {
+        textResponse += (textResponse ? '\n' : '') + nestedText;
+      }
+    }
+  }
+
+  if (structuredReply == null && textResponse) {
+    const parsed = parseStructuredText(textResponse);
+    if (parsed) {
+      structuredReply = parsed.reply ?? structuredReply;
+      if (structuredState == null) {
+        structuredState = parsed.state;
+      }
+    }
+  }
+
+  const reply = structuredReply ?? (textResponse || null);
+
+  if (reply == null && structuredState == null) {
     return null;
   }
 
   return {
-    response: text,
+    response: reply ?? '',
+    reply: reply ?? '',
+    state: structuredState,
+    rawResponse: textResponse,
     model: data.model ?? requestPayload.model,
     usage: data.usage,
     timestamp: new Date().toISOString(),
   };
+}
+
+function normalizeState(stateValue) {
+  if (stateValue == null) {
+    return null;
+  }
+
+  if (typeof stateValue === 'object') {
+    return stateValue;
+  }
+
+  if (typeof stateValue === 'string' && stateValue.trim()) {
+    try {
+      return JSON.parse(stateValue);
+    } catch (error) {
+      return stateValue;
+    }
+  }
+
+  return stateValue;
+}
+
+function parseStructuredText(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    return null;
+  }
+
+  const cleaned = stripCodeFences(text.trim());
+  const parsed = tryParseJson(cleaned) ?? tryParseEmbeddedJson(cleaned);
+
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+
+  const reply = typeof parsed.reply === 'string' ? parsed.reply : null;
+  const state = normalizeState(parsed.state);
+
+  return { reply, state };
+}
+
+function stripCodeFences(text) {
+  const fenceMatch = text.match(/^```[a-zA-Z0-9_-]*\n([\s\S]*?)```$/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+  return text;
+}
+
+function tryParseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return null;
+  }
+}
+
+function tryParseEmbeddedJson(text) {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    return null;
+  }
+
+  const snippet = text.slice(start, end + 1);
+  return tryParseJson(snippet);
 }
 
 function handleAnthropicError(res, status, data, options) {
@@ -272,7 +412,7 @@ export function createAnthropicProxyHandler(options = {}) {
 
     let requestPayload;
     try {
-      requestPayload = buildRequestPayload(body, normalized.messages, handlerOptions);
+      requestPayload = buildRequestPayload(body, normalized, handlerOptions);
     } catch (error) {
       console.error('Failed to build Anthropic payload:', error);
       return res.status(400).json({

--- a/api/_anthropicProxyHandler.js
+++ b/api/_anthropicProxyHandler.js
@@ -42,6 +42,8 @@ function toAnthropicContentBlock(text) {
   return [{ type: 'text', text }];
 }
 
+// Systemメッセージ群とユーザー/assistantターンを分離し、stateを含むsystemメッセージにフラグを付与する。
+// stateMessageContent は prepareConversationPayload が生成する「Stateを埋め込んだsystemテキスト」そのもの。
 function normalizeConversation(messages, stateMessageContent) {
   const systemMessages = [];
   const conversation = [];
@@ -55,6 +57,7 @@ function normalizeConversation(messages, stateMessageContent) {
     if (message.role === 'system') {
       systemMessages.push({
         text: trimmed,
+        // stateを埋め込んだsystemメッセージと完全一致する場合だけ動的ブロックとしてマークする。
         isState: !!stateMessageContent && trimmed === stateMessageContent,
       });
       continue;
@@ -88,6 +91,8 @@ function normalizeConversation(messages, stateMessageContent) {
   };
 }
 
+// Claudeはsystemに最大4ブロックまでcache_controlを付けられるため、超過分は後ろ側をマージする。
+// isStateフラグはマージ後のブロックにもORで引き継ぎ、"この塊は動的stateを含む"という判定を維持する。
 function limitCacheBreakpoints(blocks, maxBreakpoints = 4) {
   const limited = blocks.map(block => ({ ...block }));
 

--- a/api/_messageUtils.js
+++ b/api/_messageUtils.js
@@ -12,6 +12,15 @@ const DEFAULT_GUIDELINE = `以下のガイドラインに従って応答して�
 
 応答は200文字以内で、次の質問や気づきを促すようにしてください。`;
 
+const STRUCTURED_OUTPUT_INSTRUCTION = `必ず次の形式で応答してください。
+
+{
+  "reply": "受容文と質問文を統合したユーザー向けメッセージ",
+  "state": { ...更新後のState全体... }
+}
+
+replyには自然な文章を入れ、stateには現在の分析結果を表すJSON全体を入れてください。`;
+
 function extractBearerToken(headerValue = '') {
   if (typeof headerValue !== 'string') return '';
   const trimmed = headerValue.trim();
@@ -97,6 +106,60 @@ function buildDefaultSystemPrompt(scenarioText = '') {
   return `あなたは心理学の専門家として、メンタライズ（他者の心の理解）を教えるエージェントです。${scenario}\n\n${DEFAULT_GUIDELINE}`;
 }
 
+function serializeStateForPrompt(stateValue) {
+  if (stateValue == null) {
+    return null;
+  }
+
+  if (typeof stateValue === 'string') {
+    const trimmed = stateValue.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      return JSON.stringify(parsed, null, 2);
+    } catch (error) {
+      return trimmed;
+    }
+  }
+
+  if (typeof stateValue === 'object') {
+    try {
+      return JSON.stringify(stateValue, null, 2);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return String(stateValue);
+}
+
+function tryParseStateObject(stateValue) {
+  if (stateValue == null) {
+    return null;
+  }
+
+  if (typeof stateValue === 'object') {
+    try {
+      return JSON.parse(JSON.stringify(stateValue));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  if (typeof stateValue === 'string' && stateValue.trim()) {
+    try {
+      return JSON.parse(stateValue);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
 export function parseRequestBody(body) {
   if (!body) return {};
   if (typeof body === 'object') return body;
@@ -115,6 +178,9 @@ export function prepareConversationPayload(rawBody) {
   const providedSystemPrompt = typeof body.systemPrompt === 'string' ? body.systemPrompt.trim() : '';
   const defaultSystemPrompt = buildDefaultSystemPrompt(scenario);
   const finalSystemPrompt = providedSystemPrompt || defaultSystemPrompt;
+
+  const serializedState = serializeStateForPrompt(body.state);
+  const parsedState = tryParseStateObject(body.state);
 
   const turnCandidates = Array.isArray(body.messages)
     ? body.messages
@@ -137,6 +203,44 @@ export function prepareConversationPayload(rawBody) {
     }
   }
 
+  const expectsStructuredResponse =
+    body.expectStructuredResponse !== false && (serializedState != null || body.expectStructuredResponse === true);
+
+  if (expectsStructuredResponse) {
+    const instructionMessage = { role: 'system', content: STRUCTURED_OUTPUT_INSTRUCTION };
+
+    const existingInstructionIndex = messages.findIndex(
+      message => message.role === 'system' && message.content === STRUCTURED_OUTPUT_INSTRUCTION,
+    );
+
+    if (existingInstructionIndex === -1) {
+      const firstSystemIndex = messages.findIndex(message => message.role === 'system');
+      if (firstSystemIndex >= 0) {
+        messages.splice(firstSystemIndex + 1, 0, instructionMessage);
+      } else {
+        messages.unshift(instructionMessage);
+      }
+    }
+  }
+
+  if (serializedState) {
+    const stateMessage = {
+      role: 'system',
+      content: `現在のState JSONは次の通りです。モデルはこの内容を参照し、更新した結果をstateフィールドに返してください。\n${serializedState}`,
+    };
+
+    const lastSystemIndex = messages.reduce(
+      (lastIndex, message, index) => (message.role === 'system' ? index : lastIndex),
+      -1,
+    );
+
+    if (lastSystemIndex >= 0) {
+      messages.splice(lastSystemIndex + 1, 0, stateMessage);
+    } else {
+      messages.unshift(stateMessage);
+    }
+  }
+
   const messageText = typeof body.message === 'string' ? body.message : '';
   const hasUserTurn = messages.some(msg => msg.role === 'user');
 
@@ -154,6 +258,9 @@ export function prepareConversationPayload(rawBody) {
     scenario,
     finalSystemPrompt,
     messages,
+    serializedState,
+    parsedState,
+    expectsStructuredResponse,
   };
 }
 

--- a/api/_messageUtils.js
+++ b/api/_messageUtils.js
@@ -206,6 +206,7 @@ export function prepareConversationPayload(rawBody) {
   const expectsStructuredResponse =
     body.expectStructuredResponse !== false && (serializedState != null || body.expectStructuredResponse === true);
 
+  // (2) reply/state形式の構造化出力指示を system として差し込む
   if (expectsStructuredResponse) {
     const instructionMessage = { role: 'system', content: STRUCTURED_OUTPUT_INSTRUCTION };
 
@@ -225,6 +226,7 @@ export function prepareConversationPayload(rawBody) {
 
   let stateMessageContent = null;
 
+  // (3) 現在のStateを埋め込んだ system メッセージ（動的部分）を最後の system 直後に差し込む
   if (serializedState) {
     stateMessageContent = `現在のState JSONは次の通りです。モデルはこの内容を参照し、更新した結果をstateフィールドに返してください。\n${serializedState}`;
 

--- a/api/_messageUtils.js
+++ b/api/_messageUtils.js
@@ -226,7 +226,8 @@ export function prepareConversationPayload(rawBody) {
 
   let stateMessageContent = null;
 
-  // (3) 現在のStateを埋め込んだ system メッセージ（動的部分）を最後の system 直後に差し込む
+  // (3) 現在のStateだけを埋め込んだ system メッセージ（動的部分）を最後の system 直後に差し込む
+  //     ※ここには管理画面のプロンプト文面は再掲せず、State JSON の本文だけを入れる
   if (serializedState) {
     stateMessageContent = `現在のState JSONは次の通りです。モデルはこの内容を参照し、更新した結果をstateフィールドに返してください。\n${serializedState}`;
 

--- a/api/_messageUtils.js
+++ b/api/_messageUtils.js
@@ -223,10 +223,14 @@ export function prepareConversationPayload(rawBody) {
     }
   }
 
+  let stateMessageContent = null;
+
   if (serializedState) {
+    stateMessageContent = `現在のState JSONは次の通りです。モデルはこの内容を参照し、更新した結果をstateフィールドに返してください。\n${serializedState}`;
+
     const stateMessage = {
       role: 'system',
-      content: `現在のState JSONは次の通りです。モデルはこの内容を参照し、更新した結果をstateフィールドに返してください。\n${serializedState}`,
+      content: stateMessageContent,
     };
 
     const lastSystemIndex = messages.reduce(
@@ -260,6 +264,7 @@ export function prepareConversationPayload(rawBody) {
     messages,
     serializedState,
     parsedState,
+    stateMessageContent,
     expectsStructuredResponse,
   };
 }

--- a/api/_openaiProxyHandler.js
+++ b/api/_openaiProxyHandler.js
@@ -147,6 +147,31 @@ function buildRequestPayload(body, normalized, options) {
       .filter(Boolean);
   }
 
+  const reasoningEffort =
+    body.reasoning_effort ??
+    body.reasoningEffort ??
+    (typeof body.reasoning === 'object' ? body.reasoning.effort : null);
+  if (typeof reasoningEffort === 'string' && reasoningEffort.trim()) {
+    payload.reasoning = { effort: reasoningEffort.trim() };
+  }
+
+  const textVerbosity =
+    body.text_verbosity ??
+    body.textVerbosity ??
+    (typeof body.text === 'object' ? body.text.verbosity : null);
+  if (typeof textVerbosity === 'string' && textVerbosity.trim()) {
+    payload.text = { verbosity: textVerbosity.trim() };
+  }
+
+  const maxOutputTokens = toNumber(body.max_output_tokens, null);
+  if (maxOutputTokens != null) {
+    payload.max_output_tokens = maxOutputTokens;
+  }
+
+  if (typeof body.prompt_cache_retention === 'string' && body.prompt_cache_retention.trim()) {
+    payload.prompt_cache_retention = body.prompt_cache_retention.trim();
+  }
+
   return payload;
 }
 

--- a/api/_openaiProxyHandler.js
+++ b/api/_openaiProxyHandler.js
@@ -215,8 +215,20 @@ async function forwardToOpenAI(apiKey, payload) {
     body: JSON.stringify(payload),
   });
 
-  const data = await response.json();
-  return { response, data };
+  // API 側の一時的なエラーページなどで HTML が返る場合に備え、まずテキストで取得してから
+  // JSON パースを試みる。失敗した場合はテキストをそのままエラーとして扱う。
+  const rawText = await response.text();
+  let data = null;
+
+  if (rawText) {
+    try {
+      data = JSON.parse(rawText);
+    } catch (error) {
+      data = { error: { message: rawText } };
+    }
+  }
+
+  return { response, data: data ?? {}, rawText };
 }
 
 function normalizeOpenAIResponse(data, requestPayload) {

--- a/api/_openaiProxyHandler.js
+++ b/api/_openaiProxyHandler.js
@@ -67,13 +67,21 @@ function buildRequestPayload(body, normalized, options) {
   } = options;
 
   const model = extractModelName(body, defaultModel);
-  const temperature = toNumber(body.temperature, defaultTemperature);
+  const temperature =
+    modelSupportsCustomTemperature(model) && body.temperature !== undefined
+      ? toNumber(body.temperature, defaultTemperature)
+      : modelSupportsCustomTemperature(model)
+        ? toNumber(defaultTemperature, null)
+        : null;
 
   const payload = {
     model,
     messages: normalizedMessages,
-    temperature,
   };
+
+  if (temperature != null) {
+    payload.temperature = temperature;
+  }
 
   const explicitResponseFormat = body.response_format ?? body.responseFormat;
   if (explicitResponseFormat) {
@@ -127,6 +135,15 @@ function buildRequestPayload(body, normalized, options) {
   }
 
   return payload;
+}
+
+function modelSupportsCustomTemperature(model) {
+  if (!model || typeof model !== 'string') return true;
+  const normalized = model.toLowerCase();
+  return !(
+    normalized.startsWith('gpt-5') ||
+    normalized.startsWith('o1')
+  );
 }
 
 function buildErrorResponse(options, error) {

--- a/api/_openaiProxyHandler.js
+++ b/api/_openaiProxyHandler.js
@@ -151,7 +151,11 @@ function buildRequestPayload(body, normalized, options) {
     body.reasoning_effort ??
     body.reasoningEffort ??
     (typeof body.reasoning === 'object' ? body.reasoning.effort : null);
-  if (typeof reasoningEffort === 'string' && reasoningEffort.trim()) {
+  if (
+    typeof reasoningEffort === 'string' &&
+    reasoningEffort.trim() &&
+    modelSupportsReasoning(payload.model)
+  ) {
     payload.reasoning = { effort: reasoningEffort.trim() };
   }
 
@@ -182,6 +186,12 @@ function modelSupportsCustomTemperature(model) {
     normalized.startsWith('gpt-5') ||
     normalized.startsWith('o1')
   );
+}
+
+function modelSupportsReasoning(model) {
+  if (!model || typeof model !== 'string') return false;
+  const normalized = model.toLowerCase();
+  return normalized.startsWith('gpt-5');
 }
 
 function buildErrorResponse(options, error) {

--- a/api/_openaiProxyHandler.js
+++ b/api/_openaiProxyHandler.js
@@ -4,6 +4,33 @@ import {
   toNumber,
 } from './_messageUtils.js';
 
+const DEFAULT_RESPONSE_FORMAT = {
+  type: 'json_schema',
+  json_schema: {
+    name: 'reply_and_state',
+    schema: {
+      type: 'object',
+      properties: {
+        reply: {
+          type: 'string',
+          description:
+            'ユーザーに表示する受容文と質問文を統合したメッセージを文字列で返してください。',
+        },
+        state: {
+          description:
+            '現在の分析結果を表すState全体をJSONオブジェクトで返してください。該当する情報がなければnullを返してください。',
+          oneOf: [
+            { type: 'object', additionalProperties: true },
+            { type: 'null' },
+          ],
+        },
+      },
+      required: ['reply', 'state'],
+      additionalProperties: false,
+    },
+  },
+};
+
 /**
  * OpenAI へのリクエスト送信処理を共通化したハンドラ。
  *
@@ -28,7 +55,8 @@ function extractModelName(body, fallbackModel) {
   return fallbackModel;
 }
 
-function buildRequestPayload(body, normalizedMessages, options) {
+function buildRequestPayload(body, normalized, options) {
+  const normalizedMessages = normalized.messages;
   const {
     defaultModel,
     defaultTemperature,
@@ -46,6 +74,27 @@ function buildRequestPayload(body, normalizedMessages, options) {
     messages: normalizedMessages,
     temperature,
   };
+
+  const explicitResponseFormat = body.response_format ?? body.responseFormat;
+  if (explicitResponseFormat) {
+    payload.response_format = explicitResponseFormat;
+  } else if (normalized.expectsStructuredResponse) {
+    payload.response_format = DEFAULT_RESPONSE_FORMAT;
+  }
+
+  if (Array.isArray(body.tools)) {
+    payload.tools = body.tools;
+  }
+
+  const toolChoice = body.tool_choice ?? body.toolChoice;
+  if (toolChoice != null) {
+    payload.tool_choice = toolChoice;
+  }
+
+  const parallelToolCalls = body.parallel_tool_calls ?? body.parallelToolCalls;
+  if (parallelToolCalls != null) {
+    payload.parallel_tool_calls = parallelToolCalls;
+  }
 
   if (body.max_completion_tokens != null) {
     payload.max_completion_tokens = toNumber(
@@ -109,32 +158,112 @@ function normalizeOpenAIResponse(data, requestPayload) {
   const choice = Array.isArray(data?.choices) ? data.choices[0] : null;
   const message = choice?.message;
 
-  if (message && typeof message.content === 'string') {
-    return {
-      response: message.content,
-      model: requestPayload.model,
-      usage: data.usage,
-      timestamp: new Date().toISOString(),
-    };
+  if (!message) {
+    return null;
   }
 
-  if (message && Array.isArray(message.content)) {
-    const combined = message.content
-      .map(part => (typeof part?.text === 'string' ? part.text : ''))
+  const rawText = extractMessageText(message);
+  const structured = parseStructuredContent(rawText);
+
+  return {
+    response: structured.reply ?? rawText ?? '',
+    reply: structured.reply ?? rawText ?? '',
+    state: structured.state,
+    rawResponse: rawText ?? '',
+    model: requestPayload.model,
+    usage: data.usage,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function extractMessageText(message) {
+  if (typeof message?.content === 'string') {
+    return message.content;
+  }
+
+  if (Array.isArray(message?.content)) {
+    return message.content
+      .map(part => {
+        if (typeof part?.text === 'string') return part.text;
+        if (Array.isArray(part?.content)) {
+          return part.content
+            .map(inner => (typeof inner?.text === 'string' ? inner.text : ''))
+            .filter(Boolean)
+            .join('\n');
+        }
+        return '';
+      })
       .filter(Boolean)
       .join('\n');
+  }
 
-    if (combined) {
-      return {
-        response: combined,
-        model: requestPayload.model,
-        usage: data.usage,
-        timestamp: new Date().toISOString(),
-      };
+  return '';
+}
+
+function parseStructuredContent(rawText) {
+  if (typeof rawText !== 'string' || !rawText.trim()) {
+    return { reply: null, state: null };
+  }
+
+  const cleaned = stripCodeFences(rawText.trim());
+
+  const parsed = tryParseJson(cleaned) ?? tryParseEmbeddedJson(cleaned);
+
+  if (!parsed || typeof parsed !== 'object') {
+    return { reply: null, state: null };
+  }
+
+  const reply = typeof parsed.reply === 'string' ? parsed.reply : null;
+  const state = normalizeState(parsed.state);
+
+  return { reply, state };
+}
+
+function stripCodeFences(text) {
+  const fenceMatch = text.match(/^```[a-zA-Z0-9_-]*\n([\s\S]*?)```$/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+  return text;
+}
+
+function tryParseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return null;
+  }
+}
+
+function tryParseEmbeddedJson(text) {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    return null;
+  }
+
+  const snippet = text.slice(start, end + 1);
+  return tryParseJson(snippet);
+}
+
+function normalizeState(stateValue) {
+  if (stateValue == null) {
+    return null;
+  }
+
+  if (typeof stateValue === 'object') {
+    return stateValue;
+  }
+
+  if (typeof stateValue === 'string' && stateValue.trim()) {
+    try {
+      return JSON.parse(stateValue);
+    } catch (error) {
+      return stateValue;
     }
   }
 
-  return null;
+  return stateValue;
 }
 
 function handleOpenAiError(res, data, requestPayload) {
@@ -209,11 +338,7 @@ export function createOpenAIProxyHandler(options = {}) {
       return res.status(400).json({ error: 'OpenAI APIキーが指定されていません' });
     }
 
-    const requestPayload = buildRequestPayload(
-      body,
-      normalized.messages,
-      handlerOptions,
-    );
+    const requestPayload = buildRequestPayload(body, normalized, handlerOptions);
 
     try {
       console.log('Making request to OpenAI with model:', requestPayload.model);

--- a/api/_openaiProxyHandler.js
+++ b/api/_openaiProxyHandler.js
@@ -62,6 +62,7 @@ function buildRequestPayload(body, normalized, options) {
     defaultTemperature,
     defaultPresencePenalty,
     defaultFrequencyPenalty,
+    defaultTopP,
     defaultMaxTokens,
     defaultMaxCompletionTokens,
   } = options;
@@ -132,6 +133,18 @@ function buildRequestPayload(body, normalized, options) {
       frequencyPenalty,
       defaultFrequencyPenalty ?? 0,
     );
+  }
+
+  const topP = body.top_p ?? body.topP ?? defaultTopP ?? null;
+  if (topP != null) {
+    payload.top_p = toNumber(topP, defaultTopP ?? null);
+  }
+
+  const stop = body.stop ?? body.stop_sequences ?? body.stopSequences;
+  if (Array.isArray(stop) && stop.length) {
+    payload.stop = stop
+      .map(value => (typeof value === 'string' ? value : ''))
+      .filter(Boolean);
   }
 
   return payload;
@@ -320,6 +333,7 @@ export function createOpenAIProxyHandler(options = {}) {
     defaultTemperature: 0.7,
     defaultPresencePenalty: undefined,
     defaultFrequencyPenalty: undefined,
+    defaultTopP: undefined,
     defaultMaxTokens: 300,
     defaultMaxCompletionTokens: 300,
     internalErrorMessage: 'サーバー内部エラーが発生しました',

--- a/api/openai-proxy.js
+++ b/api/openai-proxy.js
@@ -5,12 +5,9 @@ import { createOpenAIProxyHandler } from './_openaiProxyHandler.js';
  * `_openaiProxyHandler` をそのまま利用しつつ、応答の多様性を調整するためのペナルティや
  * 本番向けのエラーメッセージ設定をここで上書きしています。
  *
- * - presence/frequency penalty を既定で 0.1 に設定し、同じ話題の繰り返しを抑制します。
  * - exposeErrorDetails: false とすることで、ユーザーに内部情報を漏らさず安全な文言を返します。
  */
 export default createOpenAIProxyHandler({
-  defaultPresencePenalty: 0.1,
-  defaultFrequencyPenalty: 0.1,
   exposeErrorDetails: false,
   internalErrorMessage: 'サーバー内部エラーが発生しました。管理者に連絡してください。',
 });

--- a/index.html
+++ b/index.html
@@ -1336,7 +1336,53 @@ function sanitizeAIText(raw) {
     let supabase = null;
     let isSupabaseAvailable = false;
     let currentAssignment = null;
-    let currentStructuredState = null;
+
+    function createInitialStructuredState() {
+      return {
+        personas: [
+          {
+            persona_id: 1,
+            persona_name: null,
+            phases: {
+              before_c: {
+                focus: { name: '未定', type: null, is_completed: false, details: null },
+                pattern_usage: {
+                  c_used: false,
+                  b_count: 0,
+                  b_categories_used: [],
+                  k_used: false,
+                  h_used: false
+                },
+                information: { reasons: [] }
+              },
+              after_c: {
+                focus: { name: '未定', type: null, is_completed: false, details: null },
+                pattern_usage: {
+                  c_used: false,
+                  b_count: 0,
+                  b_categories_used: [],
+                  k_used: false,
+                  h_used: false
+                },
+                information: { reasons: [] }
+              }
+            }
+          }
+        ],
+        global_state: {
+          current_persona_id: 1,
+          current_phase: 'before_c',
+          total_personas_analyzed: 0,
+          relationship_analysis_done: false
+        },
+        last_pattern_used: {
+          pattern: null,
+          category: null
+        }
+      };
+    }
+
+    let currentStructuredState = createInitialStructuredState();
     
     let adminConfig = {
         adminPassword: 'MentalizeAdmin2024!',
@@ -3181,7 +3227,7 @@ function sanitizeAIText(raw) {
     }
 
     function initializeChat() {
-        currentStructuredState = null;
+        currentStructuredState = createInitialStructuredState();
         const messages = document.getElementById('chatMessages');
         messages.innerHTML = '';
 
@@ -3897,7 +3943,7 @@ function sanitizeAIText(raw) {
         // セッションタイマーを停止
         stopSessionTimer();
 
-        currentStructuredState = null;
+        currentStructuredState = createInitialStructuredState();
 
         document.getElementById('experimentContent').style.display = 'none';
         document.getElementById('participantSetup').style.display = 'block';

--- a/index.html
+++ b/index.html
@@ -929,7 +929,7 @@
                             <div class="form-group">
                               <label for="openaiPromptCacheRetention">prompt_cache_retention（例: 24h）</label>
                               <input type="text" id="openaiPromptCacheRetention" placeholder="空欄で送信しない">
-                              <small style="color:#6c757d;">OpenAI側でプロンプト全体をキャッシュします（同一プロンプト・同一パラメータ時に有効）。stateもプロンプトに含まれるため、stateが変わるとキャッシュは効きません。</small>
+                              <small style="color:#6c757d;">OpenAI側でプロンプト全体をキャッシュします。同一プロンプト（先頭から一致する部分）+同一パラメータでヒットするため、静的な指示・シナリオを前半、stateなどの動的情報を後半に置くと、動的部分が変わっても静的部分のキャッシュを活かせます。</small>
                             </div>
                           </div>
                         </div>
@@ -967,7 +967,7 @@
                           <div class="form-group">
                             <label for="claudeCacheControl">cache_control.type（例: ephemeral）</label>
                             <input type="text" id="claudeCacheControl" placeholder="空欄で送信しない">
-                            <small style="color:#6c757d;">systemメッセージに cache_control を付与し、同一システムプロンプトを再利用する際に効きます。stateをsystemメッセージに埋め込んで送る設計のため、stateが変わるとキャッシュは無効になります。キャッシュは「完全に同一のプロンプト（stateを含む）＋同一パラメータ」のときだけ再利用され、部分一致や一部変更ではヒットしません。プロンプトやstate以外に独立してキャッシュできる対象は現状ありません。</small>
+                            <small style="color:#6c757d;">systemメッセージを最大4つのブロックに分割し、同一の cache_control.type を付与します。静的なプロンプトブロックはstateが変わってもキャッシュが再利用され、state付きブロックも同一stateなら再利用されます（stateが変わるとそのブロックのみ無効化）。設定項目は1つですが、静的プロンプト用とstateを含む全体用の両方に反映されます。</small>
                           </div>
                         </div>
                         <div class="form-group" style="margin-top: 10px;">

--- a/index.html
+++ b/index.html
@@ -1336,6 +1336,7 @@ function sanitizeAIText(raw) {
     let supabase = null;
     let isSupabaseAvailable = false;
     let currentAssignment = null;
+    let currentStructuredState = null;
     
     let adminConfig = {
         adminPassword: 'MentalizeAdmin2024!',
@@ -1781,6 +1782,7 @@ function sanitizeAIText(raw) {
                     analysis: logData.analysis,
                     chatHistory: logData.chatHistory,
                     model: adminConfig.model,
+                    structuredState: currentStructuredState,
                     scenarioIndex: logData.scenarioIndex ?? null,
                     scenario_id: logData.scenario_id,               // 追加：固定ID
                     snapshot: {                                     // 追加：完全再現用
@@ -1814,6 +1816,7 @@ function sanitizeAIText(raw) {
                   analysis: logData.analysis,
                   chatHistory: logData.chatHistory,
                   model: adminConfig.model,
+                  structuredState: currentStructuredState,
                   // 互換のために scenarioIndex を残す（不要になったら NULL か削除）
                   scenarioIndex: logData.scenarioIndex ?? null,
                   // 新規：固定IDと完全再現用スナップショット
@@ -3157,9 +3160,10 @@ function sanitizeAIText(raw) {
     }
 
     function initializeChat() {
+        currentStructuredState = null;
         const messages = document.getElementById('chatMessages');
         messages.innerHTML = '';
-        
+
         addMessage('ai', 'こんにちは！このシナリオについて、登場人物の気持ちや考えを一緒に探ってみましょう。まず、どの人物に注目しますか？');
         
         document.getElementById('progressFill').style.width = '50%';
@@ -3178,9 +3182,10 @@ function sanitizeAIText(raw) {
         const loadingMessageId = addLoadingMessage();
         
         try {
-            const response = await generateAIResponse(message);
+            const result = await generateAIResponse(message);
             removeLoadingMessage(loadingMessageId);
-            addMessage('ai', (response && response.trim()) ? response : '（応答が空でした）');
+            const replyText = typeof result?.reply === 'string' ? result.reply : '';
+            addMessage('ai', replyText && replyText.trim() ? replyText : '（応答が空でした）');
         } catch (error) {
             removeLoadingMessage(loadingMessageId);
             addMessage('ai', 'AIからの応答を取得できませんでした。もう一度お試しください。');
@@ -3248,33 +3253,25 @@ function sanitizeAIText(raw) {
           throw new Error('シナリオ割当が未確定です。displayScenario() が先に実行されているか確認してください。');
         }
 
-        // システムプロンプト（管理UIの systemPrompt に、シナリオの隠し文脈を足す）
-
-
-      
         // --- system prompt を一度だけ合成（管理プロンプト + 隠し文脈 + 参考質問/着目点） ---
         let systemPrompt = (adminConfig?.systemPrompt ?? '').toString();
-        
-        // 隠し文脈
+
         const hidden = (a.snapshot_hidden_context ?? '').toString();
         if (hidden) systemPrompt += (systemPrompt ? '\n\n' : '') + hidden;
-        
-        // 参考用想定質問
+
         const qs = Array.isArray(a.snapshot_prompt_questions) ? a.snapshot_prompt_questions : [];
         if (qs.length) {
           systemPrompt += '\n\n参考用想定質問:\n' + qs.map(q => `- ${q}`).join('\n');
         }
-        
-        // 分析時の着目点
+
         const ap = (a.snapshot_analysis_points ?? '').toString();
         if (ap) {
           systemPrompt += '\n\n分析時の着目点:\n' + ap;
         }
-        
+
         // 履歴とユーザー発話
         const chatHistory = (typeof getChatHistory === 'function') ? getChatHistory() : [];
 
-        // APIリクエスト用に、履歴を役割つきでコピーしつつ、直近のユーザー発話にシナリオ文脈を付与
         const historyForApi = chatHistory.map(msg => ({
           role: msg.role || (msg.sender === 'user' ? 'user' : 'assistant'),
           content: msg.content
@@ -3288,48 +3285,66 @@ function sanitizeAIText(raw) {
         } else {
           lastHistoryEntry.content = `${scenarioPreface}${lastHistoryEntry.content}`;
         }
-        
+
         if (adminConfig.apiKey) {
             try {
-                // デバッグ用: 使用中のモデルをログ出力
                 const requestStartTime = performance.now();
                 console.log(`🤖 AI Request - Provider: ${adminConfig.apiProvider}, Model: ${adminConfig.model}, Custom: ${adminConfig.useCustomModel || false}`);
-                
-                let apiUrl, headers, requestBody;
-                
+
+                let apiUrl = '';
+                let headers = {};
+                let requestBody = null;
+                let parseResponse = null;
+
                 if (adminConfig.apiProvider === 'openai') {
                     if (!adminConfig.apiKey.startsWith('sk-')) {
                         throw new Error('OpenAI APIキーの形式が正しくありません');
                     }
 
-                    apiUrl = 'https://api.openai.com/v1/chat/completions';
+                    apiUrl = '/api/openai-proxy';
                     headers = {
                         'Content-Type': 'application/json',
                         'Authorization': `Bearer ${adminConfig.apiKey}`
                     };
 
-                    const messages = [{ role: 'system', content: systemPrompt }];
-                    historyForApi.forEach(msg => {
-                        messages.push({
-                            role: msg.role,
-                            content: msg.content
-                        });
-                    });
-
                     const isGpt5 = typeof adminConfig.model === 'string' && adminConfig.model.startsWith('gpt-5');
                     requestBody = {
                         model: adminConfig.model,
-                        messages
+                        systemPrompt,
+                        scenario: a.snapshot_content,
+                        messages: historyForApi,
+                        expectStructuredResponse: true,
+                        state: currentStructuredState ?? null,
                     };
 
                     if (isGpt5) {
-                        requestBody.response_format = { type: 'text' };
                         requestBody.max_completion_tokens = adminConfig.maxTokens || 1024;
                     } else {
                         requestBody.max_tokens = adminConfig.maxTokens || 300;
                         requestBody.temperature = adminConfig.temperature ?? 0.7;
                     }
 
+                    parseResponse = data => {
+                        if (data && Object.prototype.hasOwnProperty.call(data, 'state')) {
+                            currentStructuredState = data.state;
+                        }
+
+                        const replyCandidate =
+                            (typeof data?.reply === 'string' ? data.reply : null) ??
+                            (typeof data?.response === 'string' ? data.response : null);
+                        const fallbackRaw = typeof data === 'string' ? data : '';
+                        const rawCandidate =
+                            (typeof data?.rawResponse === 'string' ? data.rawResponse : null) ??
+                            replyCandidate ??
+                            fallbackRaw;
+                        const reply = sanitizeAIText((replyCandidate ?? rawCandidate ?? '').toString());
+
+                        return {
+                            reply: reply || '(応答が空でした)',
+                            state: currentStructuredState,
+                            raw: rawCandidate || reply,
+                        };
+                    };
                 } else if (adminConfig.apiProvider === 'claude') {
                     const maxTokens = Math.max(adminConfig.maxTokens || 1024, 1);
                     apiUrl = '/api/claude-proxy';
@@ -3338,17 +3353,46 @@ function sanitizeAIText(raw) {
                         'Authorization': `Bearer ${adminConfig.apiKey}`
                     };
 
-                    const messages = historyForApi.map(msg => ({
-                        role: msg.role,
-                        content: msg.content
-                    }));
-
                     requestBody = {
                         model: adminConfig.model,
                         max_tokens: maxTokens,
                         temperature: adminConfig.temperature ?? 0.7,
                         systemPrompt,
-                        messages
+                        scenario: a.snapshot_content,
+                        messages: historyForApi,
+                        expectStructuredResponse: true,
+                        state: currentStructuredState ?? null,
+                    };
+
+                    parseResponse = data => {
+                        if (data && Object.prototype.hasOwnProperty.call(data, 'state')) {
+                            currentStructuredState = data.state;
+                        }
+
+                        let replyCandidate = '';
+                        if (typeof data?.reply === 'string') {
+                            replyCandidate = data.reply;
+                        } else if (typeof data?.response === 'string') {
+                            replyCandidate = data.response;
+                        } else if (Array.isArray(data?.content)) {
+                            replyCandidate = data.content
+                                .filter(block => block?.type === 'text' && typeof block.text === 'string')
+                                .map(block => block.text)
+                                .join('\n');
+                        } else if (typeof data === 'string') {
+                            replyCandidate = data;
+                        }
+
+                        if (!replyCandidate) {
+                            console.warn('Claude response did not contain text output:', data);
+                        }
+
+                        const reply = sanitizeAIText((replyCandidate || '').toString());
+                        return {
+                            reply: reply || '(応答が空でした)',
+                            state: currentStructuredState,
+                            raw: replyCandidate || reply,
+                        };
                     };
                 } else if (adminConfig.apiProvider === 'gemini') {
                     apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(adminConfig.model)}:generateContent?key=${encodeURIComponent(adminConfig.apiKey)}`;
@@ -3378,70 +3422,9 @@ function sanitizeAIText(raw) {
                             parts: [{ text: systemPrompt }]
                         };
                     }
-                } else if (adminConfig.apiProvider === 'custom') {
-                    if (!adminConfig.customApiUrl) {
-                        throw new Error('カスタムAPI URLが設定されていません');
-                    }
-                    
-                    apiUrl = adminConfig.customApiUrl;
-                    headers = {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${adminConfig.apiKey}`
-                    };
-                    
-                    // 会話履歴を含むメッセージを構築
-                    const messages = [{ role: 'system', content: systemPrompt }];
 
-                    historyForApi.forEach(msg => {
-                        messages.push({
-                            role: msg.role,
-                            content: msg.content
-                        });
-                    });
-                    
-                    requestBody = {
-                        model: adminConfig.model,
-                        messages: messages,
-                        ...(adminConfig.model && adminConfig.model.startsWith('gpt-5')
-                            ? { max_completion_tokens: adminConfig.maxTokens || 300 }
-                            : { max_tokens: adminConfig.maxTokens || 300 }),
-                        // temperature omitted for gpt-5
-                    };
-                }
-                
-                const response = await fetch(apiUrl, {
-                    method: 'POST',
-                    headers,
-                    body: JSON.stringify(requestBody)
-                });
-
-                if (response.ok) {
-                    const data = await response.json();
-                    let rawText = '';
-
-                    if (adminConfig.apiProvider === 'claude') {
-                        const normalizedText = typeof data?.response === 'string'
-                            ? data.response.trim()
-                            : '';
-
-                        if (normalizedText) {
-                            rawText = normalizedText;
-                        } else if (Array.isArray(data?.content)) {
-                            const textBlocks = data.content
-                                .filter(block => block?.type === 'text' && typeof block.text === 'string')
-                                .map(block => block.text);
-
-                            if (textBlocks.length) {
-                                rawText = textBlocks.join('\n');
-                            }
-                        }
-
-                        if (!rawText) {
-                            console.warn('Claude response did not contain text output:', data);
-                            rawText = '(応答にテキストが含まれていませんでした)';
-                        }
-
-                    } else if (adminConfig.apiProvider === 'gemini') {
+                    parseResponse = data => {
+                        let rawText = '';
                         const candidate = data?.candidates?.[0];
                         const parts = candidate?.content?.parts;
                         if (Array.isArray(parts)) {
@@ -3456,81 +3439,136 @@ function sanitizeAIText(raw) {
                             rawText = '(応答テキストが空でした)';
                         }
 
-                    } else {
+                        const reply = sanitizeAIText(rawText);
+                        return {
+                            reply: reply || rawText,
+                            state: currentStructuredState,
+                            raw: rawText,
+                        };
+                    };
+                } else if (adminConfig.apiProvider === 'custom') {
+                    if (!adminConfig.customApiUrl) {
+                        throw new Error('カスタムAPI URLが設定されていません');
+                    }
+
+                    apiUrl = adminConfig.customApiUrl;
+                    headers = {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${adminConfig.apiKey}`
+                    };
+
+                    const messages = [{ role: 'system', content: systemPrompt }];
+                    historyForApi.forEach(msg => {
+                        messages.push({
+                            role: msg.role,
+                            content: msg.content
+                        });
+                    });
+
+                    requestBody = {
+                        model: adminConfig.model,
+                        messages,
+                        ...(adminConfig.model && adminConfig.model.startsWith('gpt-5')
+                            ? { max_completion_tokens: adminConfig.maxTokens || 300 }
+                            : { max_tokens: adminConfig.maxTokens || 300 }),
+                    };
+
+                    parseResponse = data => {
+                        let rawText = '';
                         const choice = data?.choices?.[0] ?? null;
                         const msg = choice?.message ?? null;
 
-                        let textOut = '';
-
                         if (msg && typeof msg.output_text === 'string') {
-                            textOut = msg.output_text;
+                            rawText = msg.output_text;
                         }
-                        if (!textOut && choice && typeof choice.output_text === 'string') {
-                            textOut = choice.output_text;
+                        if (!rawText && choice && typeof choice.output_text === 'string') {
+                            rawText = choice.output_text;
                         }
-                        if (!textOut && msg && 'content' in msg) {
-                            textOut = extractTextDeep(msg.content);
+                        if (!rawText && msg && 'content' in msg) {
+                            rawText = extractTextDeep(msg.content);
                         }
-                        if (!textOut && choice && typeof choice.text === 'string') {
-                            textOut = choice.text;
+                        if (!rawText && choice && typeof choice.text === 'string') {
+                            rawText = choice.text;
                         }
-                        if (!textOut && msg && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
-                            textOut = '(ツール呼び出しのみの応答)';
+                        if (!rawText && msg && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+                            rawText = '(ツール呼び出しのみの応答)';
                         }
-                        if (!textOut && typeof data === 'string') {
-                            textOut = data;
-                        }
-
-                        textOut = (textOut || '').toString().trim();
-                        if (!textOut) {
-                            console.warn('OpenAI content normalization produced empty output. Full data:', data);
-                            textOut = '(応答テキストが空でした)';
+                        if (!rawText && typeof data === 'string') {
+                            rawText = data;
                         }
 
-                        rawText = textOut;
-                    }
+                        rawText = (rawText || '').toString().trim();
+                        if (!rawText) {
+                            console.warn('カスタムAPIの応答が空でした:', data);
+                            rawText = '(応答テキストが空でした)';
+                        }
 
-                    const requestEndTime = performance.now();
-                    const responseTime = Math.round(requestEndTime - requestStartTime);
-                    console.log(`⚡ AI Response - Time: ${responseTime}ms, Model: ${adminConfig.model}`);
+                        const reply = sanitizeAIText(rawText);
+                        return {
+                            reply: reply || rawText,
+                            state: currentStructuredState,
+                            raw: rawText,
+                        };
+                    };
+                }
 
-                    return sanitizeAIText(rawText);
-                } else {
-                    const errorPayload = await response.text();
-                    let parsedError;
-                    try {
-                        parsedError = JSON.parse(errorPayload);
-                    } catch (e) {
-                        parsedError = null;
-                    }
+                if (!apiUrl || !requestBody || typeof parseResponse !== 'function') {
+                    throw new Error('APIリクエストの構成に失敗しました');
+                }
 
+                const response = await fetch(apiUrl, {
+                    method: 'POST',
+                    headers,
+                    body: JSON.stringify(requestBody)
+                });
+
+                const contentType = response.headers.get('content-type') || '';
+                const isJsonResponse = contentType.includes('application/json');
+                const data = isJsonResponse ? await response.json() : await response.text();
+
+                if (!response.ok) {
                     let errorMsg = 'APIリクエストが失敗しました';
 
-                    if (adminConfig.apiProvider === 'claude') {
-                        const proxyMessage = typeof parsedError?.error === 'string'
-                            ? parsedError.error
-                            : parsedError?.error?.message;
-                        errorMsg = proxyMessage || errorMsg;
-
-                        if (response.status === 401) {
-                            errorMsg += ' - APIキーが無効です';
-                        } else if (response.status === 400 && errorMsg.includes('max_tokens')) {
-                            errorMsg += ' - max_tokensの値を確認してください(最小値: 1)';
-                        }
-                    } else {
-                        errorMsg = parsedError?.error?.message || errorMsg;
+                    if (typeof data === 'object' && data !== null) {
+                        errorMsg = data.error?.message || data.error || errorMsg;
+                    } else if (typeof data === 'string' && data.trim()) {
+                        errorMsg = data.trim();
                     }
 
-                    console.error(`APIエラー (${response.status}):`, parsedError ?? errorPayload);
+                    if (response.status === 401) {
+                        errorMsg += ' - APIキーが無効です';
+                    }
+
                     throw new Error(`${errorMsg} (${response.status})`);
                 }
+
+                const requestEndTime = performance.now();
+                const responseTime = Math.round(requestEndTime - requestStartTime);
+                console.log(`⚡ AI Response - Time: ${responseTime}ms, Model: ${adminConfig.model}`);
+
+                const parsed = parseResponse(data);
+                if (!parsed || typeof parsed.reply !== 'string') {
+                    console.warn('AI応答の解析結果が不正です:', parsed);
+                    return {
+                        reply: '(応答テキストが空でした)',
+                        state: currentStructuredState,
+                        raw: '',
+                    };
+                }
+
+                return parsed;
             } catch (error) {
                 console.error('AI API エラー:', error);
-                addMessage('ai', '申し訳ございません、AIサービスに接続できませんでした。デモモードで続行します。');
+                const fallbackMessage = '申し訳ございません、AIサービスに接続できませんでした。デモモードで続行します。';
+                return {
+                    reply: fallbackMessage,
+                    state: currentStructuredState,
+                    raw: fallbackMessage,
+                    error: true,
+                };
             }
         }
 
-        // デモ用の応答
         const responses = [
             "なるほど、その観点は興味深いですね。登場人物の表情や行動からも何か読み取れることはありますか？",
             "とても良い分析ですね。他の登場人物はどのような気持ちでいると思いますか？",
@@ -3539,9 +3577,15 @@ function sanitizeAIText(raw) {
             "興味深い指摘ですね。その状況で相手はどんなことを考えているでしょうか？",
             "良い視点ですね。もし自分がその立場だったら、どのように感じるでしょうか？"
         ];
-        
+
         await new Promise(resolve => setTimeout(resolve, 1000));
-        return responses[Math.floor(Math.random() * responses.length)];
+        const demoReply = responses[Math.floor(Math.random() * responses.length)];
+        return {
+            reply: demoReply,
+            state: currentStructuredState,
+            raw: demoReply,
+            demo: true,
+        };
     }
 
     async function initializeUserSession(userId) {
@@ -3790,7 +3834,9 @@ function sanitizeAIText(raw) {
     function resetExperiment() {
         // セッションタイマーを停止
         stopSessionTimer();
-        
+
+        currentStructuredState = null;
+
         document.getElementById('experimentContent').style.display = 'none';
         document.getElementById('participantSetup').style.display = 'block';
         

--- a/index.html
+++ b/index.html
@@ -929,6 +929,7 @@
                             <div class="form-group">
                               <label for="openaiPromptCacheRetention">prompt_cache_retention（例: 24h）</label>
                               <input type="text" id="openaiPromptCacheRetention" placeholder="空欄で送信しない">
+                              <small style="color:#6c757d;">OpenAI側でプロンプト全体をキャッシュします（同一プロンプト・同一パラメータ時に有効）。</small>
                             </div>
                           </div>
                         </div>
@@ -966,8 +967,12 @@
                           <div class="form-group">
                             <label for="claudeCacheControl">cache_control.type（例: ephemeral）</label>
                             <input type="text" id="claudeCacheControl" placeholder="空欄で送信しない">
-                            <small style="color:#6c757d;">systemメッセージに cache_control を付与します</small>
+                            <small style="color:#6c757d;">systemメッセージに cache_control を付与し、同一システムプロンプトを再利用する際に効きます。</small>
                           </div>
+                        </div>
+                        <div class="form-group" style="margin-top: 10px;">
+                          <button id="saveModelParamsBtn" class="btn" style="background:#4a5bdc;color:white;">モデル設定を保存</button>
+                          <small style="display:block; color:#6c757d; margin-top:6px;">OpenAI/Claudeのモデル・詳細パラメータを保存します（下の設定保存ボタンと同じ動作）。</small>
                         </div>
                         <div class="form-group">
                           <label for="sessionTimeout">セッションタイムアウト (分)</label>
@@ -4631,6 +4636,7 @@ function sanitizeAIText(raw) {
         // 設定保存
         document.getElementById('changePasswordBtn').addEventListener('click', changeAdminPassword);
         document.getElementById('saveConfigBtn').addEventListener('click', saveAdminConfig);
+        document.getElementById('saveModelParamsBtn').addEventListener('click', saveAdminConfig);
         document.getElementById('savePromptBtn').addEventListener('click', savePromptConfig);
         document.getElementById('saveSessionConfigBtn').addEventListener('click', saveSessionConfig);
         document.getElementById('saveMemoBtn').addEventListener('click', saveMemo);

--- a/index.html
+++ b/index.html
@@ -1383,7 +1383,7 @@ function sanitizeAIText(raw) {
     }
 
     let currentStructuredState = createInitialStructuredState();
-    
+
     let adminConfig = {
         adminPassword: 'MentalizeAdmin2024!',
         apiProvider: 'openai',
@@ -1397,6 +1397,15 @@ function sanitizeAIText(raw) {
         minimumSessionTime: 300, // 最低セッション時間（秒）- デフォルト5分
         systemPrompt: 'あなたは心理学の専門家として、メンタライズ（他者の心の理解）を教えるエージェントです。学生の考えを肯定的に受け止め、より深い分析を促す質問をしてください。温かく支援的な口調で話してください。'
     };
+
+    function modelSupportsCustomTemperature(modelName) {
+        if (!modelName) return true;
+        const normalized = modelName.toLowerCase();
+        return !(
+            normalized.startsWith('gpt-5') ||
+            normalized.startsWith('o1')
+        );
+    }
     
     let currentScenarioIndex = 0;
     let currentDay = 1;
@@ -3375,6 +3384,7 @@ function sanitizeAIText(raw) {
                     };
 
                     const isGpt5 = typeof adminConfig.model === 'string' && adminConfig.model.startsWith('gpt-5');
+                    const supportsCustomTemp = modelSupportsCustomTemperature(adminConfig.model);
                     requestBody = {
                         model: adminConfig.model,
                         systemPrompt,
@@ -3388,7 +3398,9 @@ function sanitizeAIText(raw) {
                         requestBody.max_completion_tokens = adminConfig.maxTokens || 1024;
                     } else {
                         requestBody.max_tokens = adminConfig.maxTokens || 300;
-                        requestBody.temperature = adminConfig.temperature ?? 0.7;
+                        if (supportsCustomTemp) {
+                            requestBody.temperature = adminConfig.temperature ?? 0.7;
+                        }
                     }
 
                     parseResponse = data => {

--- a/index.html
+++ b/index.html
@@ -897,6 +897,40 @@
                             <textarea id="openaiStopSequences" style="height:70px;" placeholder="例: ###\n</end>"></textarea>
                             <small style="color:#6c757d;">空欄のままなら送信しません</small>
                           </div>
+                          <div class="config-grid">
+                            <div class="form-group">
+                              <label for="openaiReasoningEffort">reasoning.effort（gpt-5系）</label>
+                              <select id="openaiReasoningEffort">
+                                <option value="">未指定</option>
+                                <option value="minimal">minimal</option>
+                                <option value="none">none（gpt-5.1）</option>
+                                <option value="low">low</option>
+                                <option value="medium">medium</option>
+                                <option value="high">high</option>
+                              </select>
+                              <small style="color:#6c757d;">値を空欄にすると送信しません</small>
+                            </div>
+                            <div class="form-group">
+                              <label for="openaiTextVerbosity">text.verbosity（出力詳細度）</label>
+                              <select id="openaiTextVerbosity">
+                                <option value="">未指定</option>
+                                <option value="low">low</option>
+                                <option value="medium">medium</option>
+                                <option value="high">high</option>
+                              </select>
+                              <small style="color:#6c757d;">未指定のままなら送信しません</small>
+                            </div>
+                          </div>
+                          <div class="config-grid">
+                            <div class="form-group">
+                              <label for="openaiMaxOutputTokens">max_output_tokens（推論込みの上限）</label>
+                              <input type="number" id="openaiMaxOutputTokens" step="1" min="1" placeholder="空欄で無効">
+                            </div>
+                            <div class="form-group">
+                              <label for="openaiPromptCacheRetention">prompt_cache_retention（例: 24h）</label>
+                              <input type="text" id="openaiPromptCacheRetention" placeholder="空欄で送信しない">
+                            </div>
+                          </div>
                         </div>
 
                         <div id="claudeAdvancedSettings" class="form-group" style="display: none; border: 1px solid #e9ecef; padding: 12px; border-radius: 8px;">
@@ -920,6 +954,19 @@
                             <label for="claudeThinkingBudget">thinking budget_tokens（思考モード対応モデルのみ）</label>
                             <input type="number" id="claudeThinkingBudget" step="1" min="1" placeholder="空欄で無効">
                             <small style="color:#6c757d;">空欄の場合は送信しません</small>
+                          </div>
+                          <div class="form-group">
+                            <label for="claudeThinkingToggle">thinking（思考モード）</label>
+                            <select id="claudeThinkingToggle">
+                              <option value="">未指定（送信しない）</option>
+                              <option value="enabled">enabled</option>
+                              <option value="disabled">disabled</option>
+                            </select>
+                          </div>
+                          <div class="form-group">
+                            <label for="claudeCacheControl">cache_control.type（例: ephemeral）</label>
+                            <input type="text" id="claudeCacheControl" placeholder="空欄で送信しない">
+                            <small style="color:#6c757d;">systemメッセージに cache_control を付与します</small>
                           </div>
                         </div>
                         <div class="form-group">
@@ -1452,12 +1499,18 @@ function sanitizeAIText(raw) {
           presence_penalty: null,
           frequency_penalty: null,
           stop: [],
+          reasoning_effort: null,
+          text_verbosity: null,
+          max_output_tokens: null,
+          prompt_cache_retention: null,
         },
         claudeParams: {
           top_p: null,
           top_k: null,
           stop_sequences: [],
           thinking_budget_tokens: null,
+          thinking_mode: null,
+          cache_control_type: null,
         },
         sessionTimeout: 60,
         showSessionTimer: true,
@@ -2165,12 +2218,18 @@ function sanitizeAIText(raw) {
           presence_penalty: parseNullableNumberInput('openaiPresencePenalty'),
           frequency_penalty: parseNullableNumberInput('openaiFrequencyPenalty'),
           stop: parseStopList('openaiStopSequences'),
+          reasoning_effort: (document.getElementById('openaiReasoningEffort')?.value || '').trim() || null,
+          text_verbosity: (document.getElementById('openaiTextVerbosity')?.value || '').trim() || null,
+          max_output_tokens: parseNullableNumberInput('openaiMaxOutputTokens'),
+          prompt_cache_retention: (document.getElementById('openaiPromptCacheRetention')?.value || '').trim() || null,
         };
         adminConfig.claudeParams = {
           top_p: parseNullableNumberInput('claudeTopP'),
           top_k: parseNullableNumberInput('claudeTopK'),
           stop_sequences: parseStopList('claudeStopSequences'),
           thinking_budget_tokens: parseNullableNumberInput('claudeThinkingBudget'),
+          thinking_mode: (document.getElementById('claudeThinkingToggle')?.value || '').trim() || null,
+          cache_control_type: (document.getElementById('claudeCacheControl')?.value || '').trim() || null,
         };
         adminConfig.sessionTimeout = Number(document.getElementById('sessionTimeout').value);
         adminConfig.showSessionTimer = document.getElementById('showTimer').checked;
@@ -2412,6 +2471,14 @@ function sanitizeAIText(raw) {
         if (openaiFrequencyPenaltyInput) openaiFrequencyPenaltyInput.value = adminConfig?.openaiParams?.frequency_penalty ?? '';
         const openaiStopInput = document.getElementById('openaiStopSequences');
         if (openaiStopInput) openaiStopInput.value = (adminConfig?.openaiParams?.stop || []).join('\n');
+        const openaiReasoningEffort = document.getElementById('openaiReasoningEffort');
+        if (openaiReasoningEffort) openaiReasoningEffort.value = adminConfig?.openaiParams?.reasoning_effort || '';
+        const openaiTextVerbosity = document.getElementById('openaiTextVerbosity');
+        if (openaiTextVerbosity) openaiTextVerbosity.value = adminConfig?.openaiParams?.text_verbosity || '';
+        const openaiMaxOutputTokens = document.getElementById('openaiMaxOutputTokens');
+        if (openaiMaxOutputTokens) openaiMaxOutputTokens.value = adminConfig?.openaiParams?.max_output_tokens ?? '';
+        const openaiPromptCacheRetention = document.getElementById('openaiPromptCacheRetention');
+        if (openaiPromptCacheRetention) openaiPromptCacheRetention.value = adminConfig?.openaiParams?.prompt_cache_retention || '';
 
         const claudeTopPInput = document.getElementById('claudeTopP');
         if (claudeTopPInput) claudeTopPInput.value = adminConfig?.claudeParams?.top_p ?? '';
@@ -2421,6 +2488,10 @@ function sanitizeAIText(raw) {
         if (claudeStopInput) claudeStopInput.value = (adminConfig?.claudeParams?.stop_sequences || []).join('\n');
         const claudeThinkingInput = document.getElementById('claudeThinkingBudget');
         if (claudeThinkingInput) claudeThinkingInput.value = adminConfig?.claudeParams?.thinking_budget_tokens ?? '';
+        const claudeThinkingToggle = document.getElementById('claudeThinkingToggle');
+        if (claudeThinkingToggle) claudeThinkingToggle.value = adminConfig?.claudeParams?.thinking_mode || '';
+        const claudeCacheControl = document.getElementById('claudeCacheControl');
+        if (claudeCacheControl) claudeCacheControl.value = adminConfig?.claudeParams?.cache_control_type || '';
 
         const timeoutInput = document.getElementById('sessionTimeout');
         if (timeoutInput) timeoutInput.value = adminConfig.sessionTimeout ?? 30;
@@ -3553,6 +3624,18 @@ function sanitizeAIText(raw) {
                     if (Array.isArray(openaiParams.stop) && openaiParams.stop.length) {
                         requestBody.stop = openaiParams.stop;
                     }
+                    if (openaiParams.reasoning_effort) {
+                        requestBody.reasoning = { effort: openaiParams.reasoning_effort };
+                    }
+                    if (openaiParams.text_verbosity) {
+                        requestBody.text = { verbosity: openaiParams.text_verbosity };
+                    }
+                    if (openaiParams.max_output_tokens != null) {
+                        requestBody.max_output_tokens = openaiParams.max_output_tokens;
+                    }
+                    if (openaiParams.prompt_cache_retention) {
+                        requestBody.prompt_cache_retention = openaiParams.prompt_cache_retention;
+                    }
 
                     parseResponse = data => {
                         if (data && Object.prototype.hasOwnProperty.call(data, 'state')) {
@@ -3604,8 +3687,18 @@ function sanitizeAIText(raw) {
                     if (Array.isArray(claudeParams.stop_sequences) && claudeParams.stop_sequences.length) {
                         requestBody.stop_sequences = claudeParams.stop_sequences;
                     }
-                    if (claudeParams.thinking_budget_tokens != null) {
+                    if (claudeParams.thinking_mode === 'enabled') {
+                        requestBody.thinking = { type: 'enabled' };
+                        if (claudeParams.thinking_budget_tokens != null) {
+                            requestBody.thinking.budget_tokens = claudeParams.thinking_budget_tokens;
+                        }
+                    } else if (claudeParams.thinking_mode === 'disabled') {
+                        requestBody.thinking = { type: 'disabled' };
+                    } else if (claudeParams.thinking_budget_tokens != null) {
                         requestBody.thinking = { type: 'enabled', budget_tokens: claudeParams.thinking_budget_tokens };
+                    }
+                    if (claudeParams.cache_control_type) {
+                        requestBody.system_cache_control = { type: claudeParams.cache_control_type };
                     }
 
                     parseResponse = data => {

--- a/index.html
+++ b/index.html
@@ -929,7 +929,7 @@
                             <div class="form-group">
                               <label for="openaiPromptCacheRetention">prompt_cache_retention（例: 24h）</label>
                               <input type="text" id="openaiPromptCacheRetention" placeholder="空欄で送信しない">
-                              <small style="color:#6c757d;">OpenAI側でプロンプト全体をキャッシュします（同一プロンプト・同一パラメータ時に有効）。</small>
+                              <small style="color:#6c757d;">OpenAI側でプロンプト全体をキャッシュします（同一プロンプト・同一パラメータ時に有効）。stateもプロンプトに含まれるため、stateが変わるとキャッシュは効きません。</small>
                             </div>
                           </div>
                         </div>
@@ -967,7 +967,7 @@
                           <div class="form-group">
                             <label for="claudeCacheControl">cache_control.type（例: ephemeral）</label>
                             <input type="text" id="claudeCacheControl" placeholder="空欄で送信しない">
-                            <small style="color:#6c757d;">systemメッセージに cache_control を付与し、同一システムプロンプトを再利用する際に効きます。</small>
+                            <small style="color:#6c757d;">systemメッセージに cache_control を付与し、同一システムプロンプトを再利用する際に効きます。stateをsystemメッセージに埋め込んで送る設計のため、stateが変わるとキャッシュは無効になります。</small>
                           </div>
                         </div>
                         <div class="form-group" style="margin-top: 10px;">

--- a/index.html
+++ b/index.html
@@ -875,6 +875,53 @@
                           <label for="temperature">Temperature</label>
                           <input type="number" id="temperature" value="0.7" step="0.1" min="0" max="2">
                         </div>
+                        <div id="openaiAdvancedSettings" class="form-group" style="display: none; border: 1px solid #e9ecef; padding: 12px; border-radius: 8px;">
+                          <label style="font-weight: 700;">OpenAIモデル詳細設定</label>
+                          <small style="display:block; color:#6c757d; margin-bottom:8px;">未入力の項目はリクエストに含めません（非対応モデルでのエラー回避）</small>
+                          <div class="config-grid">
+                            <div class="form-group">
+                              <label for="openaiTopP">top_p (0〜1)</label>
+                              <input type="number" id="openaiTopP" step="0.01" min="0" max="1" placeholder="空欄で無効">
+                            </div>
+                            <div class="form-group">
+                              <label for="openaiPresencePenalty">presence_penalty (-2〜2)</label>
+                              <input type="number" id="openaiPresencePenalty" step="0.1" min="-2" max="2" placeholder="空欄で無効">
+                            </div>
+                            <div class="form-group">
+                              <label for="openaiFrequencyPenalty">frequency_penalty (-2〜2)</label>
+                              <input type="number" id="openaiFrequencyPenalty" step="0.1" min="-2" max="2" placeholder="空欄で無効">
+                            </div>
+                          </div>
+                          <div class="form-group">
+                            <label for="openaiStopSequences">stop（改行区切り）</label>
+                            <textarea id="openaiStopSequences" style="height:70px;" placeholder="例: ###\n</end>"></textarea>
+                            <small style="color:#6c757d;">空欄のままなら送信しません</small>
+                          </div>
+                        </div>
+
+                        <div id="claudeAdvancedSettings" class="form-group" style="display: none; border: 1px solid #e9ecef; padding: 12px; border-radius: 8px;">
+                          <label style="font-weight: 700;">Claudeモデル詳細設定</label>
+                          <small style="display:block; color:#6c757d; margin-bottom:8px;">空欄のパラメータは送信しません（モデル非対応を考慮）</small>
+                          <div class="config-grid">
+                            <div class="form-group">
+                              <label for="claudeTopP">top_p (0〜1)</label>
+                              <input type="number" id="claudeTopP" step="0.01" min="0" max="1" placeholder="空欄で無効">
+                            </div>
+                            <div class="form-group">
+                              <label for="claudeTopK">top_k</label>
+                              <input type="number" id="claudeTopK" step="1" min="1" placeholder="空欄で無効">
+                            </div>
+                          </div>
+                          <div class="form-group">
+                            <label for="claudeStopSequences">stop_sequences（改行区切り）</label>
+                            <textarea id="claudeStopSequences" style="height:70px;" placeholder="例: ###\n</end>"></textarea>
+                          </div>
+                          <div class="form-group">
+                            <label for="claudeThinkingBudget">thinking budget_tokens（思考モード対応モデルのみ）</label>
+                            <input type="number" id="claudeThinkingBudget" step="1" min="1" placeholder="空欄で無効">
+                            <small style="color:#6c757d;">空欄の場合は送信しません</small>
+                          </div>
+                        </div>
                         <div class="form-group">
                           <label for="sessionTimeout">セッションタイムアウト (分)</label>
                           <input type="number" id="sessionTimeout" value="30" min="1">
@@ -889,6 +936,14 @@
                     <button id="saveConfigBtn" class="btn">設定を保存</button>
                 </div>
                 
+                <div class="admin-config">
+                    <h3>🗒️ モデルパラメータメモ</h3>
+                    <div class="form-group">
+                        <label for="modelNotes">モデルごとの対応パラメータの備忘録</label>
+                        <textarea id="modelNotes" style="height: 100px;" placeholder="例: gpt-5.1 は temperature 固定、Claude 4.5 は thinking budget 対応 など"></textarea>
+                    </div>
+                </div>
+
                 <div class="admin-config">
                     <h3>💬 システムプロンプト</h3>
                     <div class="form-group">
@@ -1392,11 +1447,31 @@ function sanitizeAIText(raw) {
         model: 'gpt-3.5-turbo',
         maxTokens: 1000,
         temperature: 0.7,
+        openaiParams: {
+          top_p: null,
+          presence_penalty: null,
+          frequency_penalty: null,
+          stop: [],
+        },
+        claudeParams: {
+          top_p: null,
+          top_k: null,
+          stop_sequences: [],
+          thinking_budget_tokens: null,
+        },
         sessionTimeout: 60,
         showSessionTimer: true,
         minimumSessionTime: 300, // 最低セッション時間（秒）- デフォルト5分
-        systemPrompt: 'あなたは心理学の専門家として、メンタライズ（他者の心の理解）を教えるエージェントです。学生の考えを肯定的に受け止め、より深い分析を促す質問をしてください。温かく支援的な口調で話してください。'
+        systemPrompt: 'あなたは心理学の専門家として、メンタライズ（他者の心の理解）を教えるエージェントです。学生の考えを肯定的に受け止め、より深い分析を促す質問をしてください。温かく支援的な口調で話してください。',
+        modelNotes: '',
     };
+
+    function mergeAdminConfig(base, incoming = {}) {
+        const merged = { ...base, ...incoming };
+        merged.openaiParams = { ...(base.openaiParams || {}), ...(incoming.openaiParams || {}) };
+        merged.claudeParams = { ...(base.claudeParams || {}), ...(incoming.claudeParams || {}) };
+        return merged;
+    }
 
     function modelSupportsCustomTemperature(modelName) {
         if (!modelName) return true;
@@ -1597,7 +1672,7 @@ function sanitizeAIText(raw) {
             if (error && error.code !== 'PGRST116') throw error;
             
             if (data) {
-                adminConfig = { ...adminConfig, ...data.settings };
+                adminConfig = mergeAdminConfig(adminConfig, data.settings || {});
               } else {
                 console.log('admin_config 行が存在しないため、デフォルト設定を使用します');
             }
@@ -1906,7 +1981,7 @@ function sanitizeAIText(raw) {
         const savedConfig = localStorage.getItem('mentalizeAdminConfig');
         if (savedConfig) {
             try {
-                adminConfig = { ...adminConfig, ...JSON.parse(savedConfig) };
+                adminConfig = mergeAdminConfig(adminConfig, JSON.parse(savedConfig));
             } catch (error) {
                 console.warn('管理者設定読み込みエラー:', error);
             }
@@ -2018,6 +2093,24 @@ function sanitizeAIText(raw) {
         selectMode('none');
     }
 
+    function parseNullableNumberInput(elementId) {
+        const el = document.getElementById(elementId);
+        if (!el) return null;
+        const value = el.value;
+        if (value === '' || value == null) return null;
+        const num = Number(value);
+        return Number.isFinite(num) ? num : null;
+    }
+
+    function parseStopList(elementId) {
+        const el = document.getElementById(elementId);
+        if (!el) return [];
+        return el.value
+            .split(/\r?\n/)
+            .map(v => v.trim())
+            .filter(v => v.length > 0);
+    }
+
     // 管理者パスワード変更
     async function changeAdminPassword() {
         const newPassword = document.getElementById('newAdminPassword').value;
@@ -2067,8 +2160,21 @@ function sanitizeAIText(raw) {
         
         adminConfig.maxTokens = Number(document.getElementById('maxTokens').value);
         adminConfig.temperature = Number(document.getElementById('temperature').value);
+        adminConfig.openaiParams = {
+          top_p: parseNullableNumberInput('openaiTopP'),
+          presence_penalty: parseNullableNumberInput('openaiPresencePenalty'),
+          frequency_penalty: parseNullableNumberInput('openaiFrequencyPenalty'),
+          stop: parseStopList('openaiStopSequences'),
+        };
+        adminConfig.claudeParams = {
+          top_p: parseNullableNumberInput('claudeTopP'),
+          top_k: parseNullableNumberInput('claudeTopK'),
+          stop_sequences: parseStopList('claudeStopSequences'),
+          thinking_budget_tokens: parseNullableNumberInput('claudeThinkingBudget'),
+        };
         adminConfig.sessionTimeout = Number(document.getElementById('sessionTimeout').value);
         adminConfig.showSessionTimer = document.getElementById('showTimer').checked;
+        adminConfig.modelNotes = document.getElementById('modelNotes')?.value || '';
         await saveAdminSettings();
         
         document.getElementById('configStatus').innerHTML = '<div class="status success">設定が保存されました！</div>';
@@ -2298,14 +2404,35 @@ function sanitizeAIText(raw) {
         const tempInput = document.getElementById('temperature');
         if (tempInput) tempInput.value = adminConfig.temperature ?? 0.7;
 
+        const openaiTopPInput = document.getElementById('openaiTopP');
+        if (openaiTopPInput) openaiTopPInput.value = adminConfig?.openaiParams?.top_p ?? '';
+        const openaiPresencePenaltyInput = document.getElementById('openaiPresencePenalty');
+        if (openaiPresencePenaltyInput) openaiPresencePenaltyInput.value = adminConfig?.openaiParams?.presence_penalty ?? '';
+        const openaiFrequencyPenaltyInput = document.getElementById('openaiFrequencyPenalty');
+        if (openaiFrequencyPenaltyInput) openaiFrequencyPenaltyInput.value = adminConfig?.openaiParams?.frequency_penalty ?? '';
+        const openaiStopInput = document.getElementById('openaiStopSequences');
+        if (openaiStopInput) openaiStopInput.value = (adminConfig?.openaiParams?.stop || []).join('\n');
+
+        const claudeTopPInput = document.getElementById('claudeTopP');
+        if (claudeTopPInput) claudeTopPInput.value = adminConfig?.claudeParams?.top_p ?? '';
+        const claudeTopKInput = document.getElementById('claudeTopK');
+        if (claudeTopKInput) claudeTopKInput.value = adminConfig?.claudeParams?.top_k ?? '';
+        const claudeStopInput = document.getElementById('claudeStopSequences');
+        if (claudeStopInput) claudeStopInput.value = (adminConfig?.claudeParams?.stop_sequences || []).join('\n');
+        const claudeThinkingInput = document.getElementById('claudeThinkingBudget');
+        if (claudeThinkingInput) claudeThinkingInput.value = adminConfig?.claudeParams?.thinking_budget_tokens ?? '';
+
         const timeoutInput = document.getElementById('sessionTimeout');
         if (timeoutInput) timeoutInput.value = adminConfig.sessionTimeout ?? 30;
 
         const showTimerCheckbox = document.getElementById('showTimer');
         if (showTimerCheckbox) showTimerCheckbox.checked = adminConfig.showSessionTimer ?? true;
-        
+
         const systemPromptInput = document.getElementById('systemPrompt');
         if (systemPromptInput) systemPromptInput.value = adminConfig.systemPrompt || '';
+
+        const modelNotesInput = document.getElementById('modelNotes');
+        if (modelNotesInput) modelNotesInput.value = adminConfig.modelNotes || '';
 
         const minimumSessionTimeInput = document.getElementById('minimumSessionTime');
         if (minimumSessionTimeInput) minimumSessionTimeInput.value = Math.floor((adminConfig.minimumSessionTime || 300) / 60); // 秒を分に変換
@@ -2315,16 +2442,26 @@ function sanitizeAIText(raw) {
     }
     
     // APIプロバイダーUIの更新
-    function updateApiProviderUI() {
-        const provider = document.getElementById('apiProvider')?.value;
-        const customUrlGroup = document.getElementById('customUrlGroup');
-        
-        if (customUrlGroup) {
-            customUrlGroup.style.display = provider === 'custom' ? 'block' : 'none';
-        }
-        
-        updateModelOptions();
-    }
+      function updateApiProviderUI() {
+          const provider = document.getElementById('apiProvider')?.value;
+          const customUrlGroup = document.getElementById('customUrlGroup');
+
+          if (customUrlGroup) {
+              customUrlGroup.style.display = provider === 'custom' ? 'block' : 'none';
+          }
+
+          const openaiAdv = document.getElementById('openaiAdvancedSettings');
+          if (openaiAdv) {
+              openaiAdv.style.display = provider === 'openai' ? 'block' : 'none';
+          }
+
+          const claudeAdv = document.getElementById('claudeAdvancedSettings');
+          if (claudeAdv) {
+              claudeAdv.style.display = provider === 'claude' ? 'block' : 'none';
+          }
+
+          updateModelOptions();
+      }
     
     // モデル選択肢の更新
     function updateModelOptions() {
@@ -3403,6 +3540,20 @@ function sanitizeAIText(raw) {
                         }
                     }
 
+                    const openaiParams = adminConfig?.openaiParams || {};
+                    if (openaiParams.top_p != null) {
+                        requestBody.top_p = openaiParams.top_p;
+                    }
+                    if (openaiParams.presence_penalty != null) {
+                        requestBody.presence_penalty = openaiParams.presence_penalty;
+                    }
+                    if (openaiParams.frequency_penalty != null) {
+                        requestBody.frequency_penalty = openaiParams.frequency_penalty;
+                    }
+                    if (Array.isArray(openaiParams.stop) && openaiParams.stop.length) {
+                        requestBody.stop = openaiParams.stop;
+                    }
+
                     parseResponse = data => {
                         if (data && Object.prototype.hasOwnProperty.call(data, 'state')) {
                             currentStructuredState = data.state;
@@ -3442,6 +3593,20 @@ function sanitizeAIText(raw) {
                         expectStructuredResponse: true,
                         state: currentStructuredState ?? null,
                     };
+
+                    const claudeParams = adminConfig?.claudeParams || {};
+                    if (claudeParams.top_p != null) {
+                        requestBody.top_p = claudeParams.top_p;
+                    }
+                    if (claudeParams.top_k != null) {
+                        requestBody.top_k = claudeParams.top_k;
+                    }
+                    if (Array.isArray(claudeParams.stop_sequences) && claudeParams.stop_sequences.length) {
+                        requestBody.stop_sequences = claudeParams.stop_sequences;
+                    }
+                    if (claudeParams.thinking_budget_tokens != null) {
+                        requestBody.thinking = { type: 'enabled', budget_tokens: claudeParams.thinking_budget_tokens };
+                    }
 
                     parseResponse = data => {
                         if (data && Object.prototype.hasOwnProperty.call(data, 'state')) {

--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,8 @@ function sanitizeAIText(raw) {
                     snapshot: {                                     // 追加：完全再現用
                       title: logData.snapshot_title,
                       content: logData.snapshot_content
-                    }
+                    },
+                    sessionDuration: logData.sessionDuration ?? null
                 },
                 created_at: new Date().toISOString()
             };
@@ -1824,7 +1825,8 @@ function sanitizeAIText(raw) {
                   snapshot: {
                     title: logData.snapshot_title,
                     content: logData.snapshot_content
-                  }
+                  },
+                  sessionDuration: logData.sessionDuration ?? null
                 }
               };
 
@@ -2715,13 +2717,20 @@ function sanitizeAIText(raw) {
         filteredLogs.forEach(log => {
             const item = document.createElement('div');
             item.style.cssText = 'background: white; border: 2px solid #e9ecef; border-radius: 15px; padding: 20px; margin-bottom: 15px;';
-            
+
             const date = new Date(log.created_at).toLocaleString('ja-JP');
             const typeLabels = {
                 'self_analysis': '自力分析',
                 'agent_assisted': 'エージェント支援'
             };
-            
+
+            const durationInfo = log.data?.sessionDuration;
+            const durationLabel = typeof durationInfo?.formatted === 'string' ? durationInfo.formatted : '';
+            const durationSeconds = Number.isFinite(durationInfo?.seconds) ? durationInfo.seconds : null;
+            const durationHtml = durationLabel
+                ? `<div style="margin-bottom: 10px;"><strong>経過時間:</strong> ${durationLabel}${durationSeconds !== null ? ` (${durationSeconds}秒)` : ''}</div>`
+                : '';
+
             let content = '';
             if (log.experiment_type === 'self_analysis') {
                 content = `<div><strong>分析内容:</strong><br>${log.data?.analysis || ''}</div>`;
@@ -2740,6 +2749,7 @@ function sanitizeAIText(raw) {
                     <div style="font-size: 14px; color: #6c757d;">${date}</div>
                 </div>
                 ${log.scenario_title ? `<div style="margin-bottom: 10px;"><strong>シナリオ:</strong> ${log.scenario_title}</div>` : ''}
+                ${durationHtml}
                 ${content}
             `;
             list.appendChild(item);
@@ -2752,8 +2762,8 @@ function sanitizeAIText(raw) {
             return;
         }
         
-        let csv = 'ID,参加者ID,実験日,実験タイプ,シナリオ,データ,タイムスタンプ\n';
-        
+        let csv = 'ID,参加者ID,実験日,実験タイプ,シナリオ,データ,タイムスタンプ,経過時間(表示),経過時間(秒)\n';
+
         experimentLogs.forEach(log => {
             let data = '';
             if (log.experiment_type === 'self_analysis') {
@@ -2761,8 +2771,12 @@ function sanitizeAIText(raw) {
             } else if (log.experiment_type === 'agent_assisted') {
                 data = log.data?.chatHistory?.map(msg => `${msg.sender}: ${msg.content}`).join(' | ') || '';
             }
-            
-            csv += `"${log.id}","${log.participant_id}","${log.day || ''}","${log.experiment_type}","${log.scenario_title || ''}","${data}","${log.created_at}"\n`;
+
+            const durationInfo = log.data?.sessionDuration;
+            const durationLabel = typeof durationInfo?.formatted === 'string' ? durationInfo.formatted : '';
+            const durationSeconds = Number.isFinite(durationInfo?.seconds) ? durationInfo.seconds : '';
+
+            csv += `"${log.id}","${log.participant_id}","${log.day || ''}","${log.experiment_type}","${log.scenario_title || ''}","${data}","${log.created_at}","${durationLabel}","${durationSeconds}"\n`;
         });
         
         const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -2901,6 +2915,9 @@ function sanitizeAIText(raw) {
         
         logs.forEach(log => {
             const date = new Date(log.created_at).toLocaleString('ja-JP');
+            const durationInfo = log.data?.sessionDuration;
+            const durationLabel = typeof durationInfo?.formatted === 'string' ? durationInfo.formatted : '';
+            const durationSeconds = Number.isFinite(durationInfo?.seconds) ? durationInfo.seconds : null;
             logsHtml += `
                 <div style="border: 1px solid #e9ecef; margin-bottom: 15px; border-radius: 8px; padding: 15px; background: #f8f9fa;">
                     <div style="display: flex; justify-content: space-between; margin-bottom: 10px;">
@@ -2908,8 +2925,9 @@ function sanitizeAIText(raw) {
                         <span style="color: #6c757d; font-size: 16px;">${date}</span>
                     </div>
                     <div style="margin-bottom: 10px;"><strong>シナリオ:</strong> ${log.scenario_title}</div>
+                    ${durationLabel ? `<div style="margin-bottom: 10px;"><strong>経過時間:</strong> ${durationLabel}${durationSeconds !== null ? ` (${durationSeconds}秒)` : ''}</div>` : ''}
             `;
-            
+
             if (log.data && log.data.chatHistory && log.data.chatHistory.length > 0) {
                 logsHtml += `
                     <div style="margin-top: 10px;">
@@ -3135,6 +3153,8 @@ function sanitizeAIText(raw) {
        const experimentType =
          (currentDay === 1 || currentDay === 7) ? 'self_analysis' : 'agent_assisted';
         
+       const sessionDuration = getSessionElapsedInfo();
+
        await saveExperimentLog({
          participantId,
          day: currentDay,
@@ -3145,7 +3165,8 @@ function sanitizeAIText(raw) {
          analysis,
          chatHistory: getChatHistory(),
          experimentType,
-         snapshot_content: currentAssignment.snapshot_content
+         snapshot_content: currentAssignment.snapshot_content,
+         sessionDuration
        });
         
         // 実験終了時のアンケートをチェック
@@ -3718,6 +3739,8 @@ function sanitizeAIText(raw) {
             return;
         }
 
+        const sessionDuration = getSessionElapsedInfo();
+
         await saveExperimentLog({
           participantId,
           day: currentDay,
@@ -3729,7 +3752,8 @@ function sanitizeAIText(raw) {
           snapshot_title: currentAssignment.snapshot_title,
           snapshot_content: currentAssignment.snapshot_content,
             // 互換が要るなら null で残す
-          scenarioIndex: null
+          scenarioIndex: null,
+          sessionDuration
 
         });
         
@@ -3756,50 +3780,85 @@ function sanitizeAIText(raw) {
     let timerInterval = null;
     let accumulatedTime = 0; // 蓄積された経過時間（ミリ秒）
     let isPaused = false;
-    
+
+    function formatDuration(milliseconds) {
+        const safeMs = Number.isFinite(milliseconds) && milliseconds > 0 ? milliseconds : 0;
+        const totalSeconds = Math.floor(safeMs / 1000);
+        const hours = Math.floor(totalSeconds / 3600).toString().padStart(2, '0');
+        const minutes = Math.floor((totalSeconds % 3600) / 60).toString().padStart(2, '0');
+        const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+        return `${hours}:${minutes}:${seconds}`;
+    }
+
+    function getSessionElapsedInfo() {
+        let elapsedMs = accumulatedTime;
+        if (sessionStartTime && !isPaused) {
+            elapsedMs += new Date() - sessionStartTime;
+        }
+
+        if (!Number.isFinite(elapsedMs) || elapsedMs < 0) {
+            elapsedMs = 0;
+        }
+
+        return {
+            milliseconds: elapsedMs,
+            seconds: Math.round(elapsedMs / 1000),
+            formatted: formatDuration(elapsedMs)
+        };
+    }
+
+    function updateSessionTimerDisplay() {
+        const timerElement = document.getElementById('timerDisplay');
+        if (!timerElement) {
+            console.error('❌ timerDisplay要素が見つかりません');
+            return;
+        }
+        timerElement.textContent = getSessionElapsedInfo().formatted;
+    }
+
+    function resetSessionTimerDisplay() {
+        const timerElement = document.getElementById('timerDisplay');
+        if (!timerElement) {
+            console.error('❌ timerDisplay要素が見つかりません');
+            return;
+        }
+        timerElement.textContent = formatDuration(0);
+    }
+
     // セッションタイマーを開始する関数
     function startSessionTimer() {
         console.log('🕐 セッションタイマー開始要求:', adminConfig.showSessionTimer);
-        
+
         // 管理者設定でタイマー表示が有効な場合のみ表示
         if (adminConfig.showSessionTimer) {
             document.getElementById('sessionTimer').style.display = 'block';
             console.log('✅ セッションタイマーを表示します');
         } else {
             document.getElementById('sessionTimer').style.display = 'none';
-            console.log('⚠️ セッションタイマーは無効に設定されています');
-            return; // タイマー表示が無効な場合は処理を終了
+            console.log('⚠️ セッションタイマーは非表示設定ですが計測は継続します');
         }
-        
+
+        accumulatedTime = 0;
+        isPaused = false;
         sessionStartTime = new Date();
-        
+
         // 既存のタイマーがあれば停止
         if (timerInterval) {
             clearInterval(timerInterval);
         }
-        
+
+        updateSessionTimerDisplay();
+
         // 1秒ごとにタイマーを更新
         timerInterval = setInterval(() => {
             if (sessionStartTime && !isPaused) {
-                const currentElapsed = new Date() - sessionStartTime;
-                const totalElapsed = accumulatedTime + currentElapsed;
-                const hours = Math.floor(totalElapsed / 3600000);
-                const minutes = Math.floor((totalElapsed % 3600000) / 60000);
-                const seconds = Math.floor((totalElapsed % 60000) / 1000);
-                
-                const timeString = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-                const timerElement = document.getElementById('timerDisplay');
-                if (timerElement) {
-                    timerElement.textContent = timeString;
-                } else {
-                    console.error('❌ timerDisplay要素が見つかりません');
-                }
+                updateSessionTimerDisplay();
             }
         }, 1000);
-        
+
         console.log('✅ セッションタイマーが開始されました');
     }
-    
+
     // セッションタイマーを停止する関数
     function stopSessionTimer() {
         if (timerInterval) {
@@ -3810,8 +3869,9 @@ function sanitizeAIText(raw) {
         accumulatedTime = 0;
         isPaused = false;
         document.getElementById('sessionTimer').style.display = 'none';
+        resetSessionTimerDisplay();
     }
-    
+
     // セッションタイマーを一時停止する関数
     function pauseSessionTimer() {
         if (sessionStartTime && !isPaused) {
@@ -3819,15 +3879,17 @@ function sanitizeAIText(raw) {
             isPaused = true;
             sessionStartTime = null;
             console.log('⏸️ セッションタイマーが一時停止されました');
+            updateSessionTimerDisplay();
         }
     }
-    
+
     // セッションタイマーを再開する関数
     function resumeSessionTimer() {
         if (isPaused) {
             sessionStartTime = new Date();
             isPaused = false;
             console.log('▶️ セッションタイマーが再開されました');
+            updateSessionTimerDisplay();
         }
     }
     

--- a/index.html
+++ b/index.html
@@ -971,10 +971,6 @@
                             <small style="color:#6c757d; display:block;">この3つの system メッセージだけを最大4ブロックに分割し、同じ cache_control.type を付与します。静的ブロック（①②）は State が変わっても再利用され、State を含む動的ブロック（③のみ、または③を含むマージブロック）は同一の State でのみ再利用されます。</small>
                           </div>
                         </div>
-                        <div class="form-group" style="margin-top: 10px;">
-                          <button id="saveModelParamsBtn" class="btn" style="background:#4a5bdc;color:white;">モデル設定を保存</button>
-                          <small style="display:block; color:#6c757d; margin-top:6px;">OpenAI/Claudeのモデル・詳細パラメータを保存します（下の設定保存ボタンと同じ動作）。</small>
-                        </div>
                         <div class="form-group">
                           <label for="sessionTimeout">セッションタイムアウト (分)</label>
                           <input type="number" id="sessionTimeout" value="30" min="1">
@@ -995,6 +991,7 @@
                         <label for="modelNotes">モデルごとの対応パラメータの備忘録</label>
                         <textarea id="modelNotes" style="height: 100px;" placeholder="例: gpt-5.1 は temperature 固定、Claude 4.5 は thinking budget 対応 など"></textarea>
                     </div>
+                    <button id="saveModelNotesBtn" class="btn">モデルパラメータメモを保存</button>
                 </div>
 
                 <div class="admin-config">
@@ -2251,6 +2248,13 @@ function sanitizeAIText(raw) {
         adminConfig.adminMemo = document.getElementById('adminMemo').value;
         await saveAdminSettings();
         alert('メモが保存されました！');
+    }
+
+    // モデルパラメータメモ保存
+    async function saveModelNotes() {
+        adminConfig.modelNotes = document.getElementById('modelNotes')?.value || '';
+        await saveAdminSettings();
+        alert('モデルパラメータメモを保存しました！');
     }
     
     // カスタムモデル入力フィールドの表示/非表示
@@ -4637,10 +4641,10 @@ function sanitizeAIText(raw) {
         // 設定保存
         document.getElementById('changePasswordBtn').addEventListener('click', changeAdminPassword);
         document.getElementById('saveConfigBtn').addEventListener('click', saveAdminConfig);
-        document.getElementById('saveModelParamsBtn').addEventListener('click', saveAdminConfig);
         document.getElementById('savePromptBtn').addEventListener('click', savePromptConfig);
         document.getElementById('saveSessionConfigBtn').addEventListener('click', saveSessionConfig);
         document.getElementById('saveMemoBtn').addEventListener('click', saveMemo);
+        document.getElementById('saveModelNotesBtn').addEventListener('click', saveModelNotes);
         
         // モデル関連イベント
         document.getElementById('modelSelect').addEventListener('change', updateCustomModelVisibility);

--- a/index.html
+++ b/index.html
@@ -967,7 +967,7 @@
                           <div class="form-group">
                             <label for="claudeCacheControl">cache_control.type（例: ephemeral）</label>
                             <input type="text" id="claudeCacheControl" placeholder="空欄で送信しない">
-                            <small style="color:#6c757d;">systemメッセージに cache_control を付与し、同一システムプロンプトを再利用する際に効きます。stateをsystemメッセージに埋め込んで送る設計のため、stateが変わるとキャッシュは無効になります。</small>
+                            <small style="color:#6c757d;">systemメッセージに cache_control を付与し、同一システムプロンプトを再利用する際に効きます。stateをsystemメッセージに埋め込んで送る設計のため、stateが変わるとキャッシュは無効になります。キャッシュは「完全に同一のプロンプト（stateを含む）＋同一パラメータ」のときだけ再利用され、部分一致や一部変更ではヒットしません。プロンプトやstate以外に独立してキャッシュできる対象は現状ありません。</small>
                           </div>
                         </div>
                         <div class="form-group" style="margin-top: 10px;">

--- a/index.html
+++ b/index.html
@@ -967,8 +967,8 @@
                           <div class="form-group">
                             <label for="claudeCacheControl">cache_control.type（例: ephemeral）</label>
                             <input type="text" id="claudeCacheControl" placeholder="空欄で送信しない">
-                            <small style="color:#6c757d; display:block;">対象は <strong>systemメッセージのみ</strong> です（ユーザー/assistantの履歴は分割されません）。構成は (1) 管理画面で入力した基本システムプロンプト＋シナリオ、(2) reply/state 形式の構造化出力指示、(3) 現在の State JSON を埋め込んだ system メッセージ の順で1列に並びます。</small>
-                            <small style="color:#6c757d; display:block;">上記の system メッセージ列を最大4ブロックに分割し、同じ cache_control.type を付与します。静的プロンプトだけのブロックは State が変わっても再利用され、State を含むブロックは同一の State でのみ再利用されます（State が変わるとそのブロックだけが無効化）。</small>
+                            <small style="color:#6c757d; display:block;">対象は <strong>systemメッセージのみ</strong> です（ユーザー/assistantの履歴は分割されません）。列の内容は①管理画面の基本システムプロンプト＋シナリオ（静的）→②reply/state 形式の構造化出力指示（静的）→③「現在の State JSON は以下」のように <u>State 本文だけを埋め込んだ system メッセージ</u>（動的）の順です。③には管理画面プロンプトは再掲されず、最新の State JSON だけが入ります。</small>
+                            <small style="color:#6c757d; display:block;">この3つの system メッセージだけを最大4ブロックに分割し、同じ cache_control.type を付与します。静的ブロック（①②）は State が変わっても再利用され、State を含む動的ブロック（③のみ、または③を含むマージブロック）は同一の State でのみ再利用されます。</small>
                           </div>
                         </div>
                         <div class="form-group" style="margin-top: 10px;">

--- a/index.html
+++ b/index.html
@@ -967,7 +967,8 @@
                           <div class="form-group">
                             <label for="claudeCacheControl">cache_control.type（例: ephemeral）</label>
                             <input type="text" id="claudeCacheControl" placeholder="空欄で送信しない">
-                            <small style="color:#6c757d;">systemメッセージを最大4つのブロックに分割し、同一の cache_control.type を付与します。静的なプロンプトブロックはstateが変わってもキャッシュが再利用され、state付きブロックも同一stateなら再利用されます（stateが変わるとそのブロックのみ無効化）。設定項目は1つですが、静的プロンプト用とstateを含む全体用の両方に反映されます。</small>
+                            <small style="color:#6c757d; display:block;">対象は <strong>systemメッセージのみ</strong> です（ユーザー/assistantの履歴は分割されません）。構成は (1) 管理画面で入力した基本システムプロンプト＋シナリオ、(2) reply/state 形式の構造化出力指示、(3) 現在の State JSON を埋め込んだ system メッセージ の順で1列に並びます。</small>
+                            <small style="color:#6c757d; display:block;">上記の system メッセージ列を最大4ブロックに分割し、同じ cache_control.type を付与します。静的プロンプトだけのブロックは State が変わっても再利用され、State を含むブロックは同一の State でのみ再利用されます（State が変わるとそのブロックだけが無効化）。</small>
                           </div>
                         </div>
                         <div class="form-group" style="margin-top: 10px;">

--- a/index.html
+++ b/index.html
@@ -1537,6 +1537,11 @@ function sanitizeAIText(raw) {
             normalized.startsWith('o1')
         );
     }
+
+    function modelSupportsReasoning(modelName) {
+        if (!modelName) return false;
+        return modelName.toLowerCase().startsWith('gpt-5');
+    }
     
     let currentScenarioIndex = 0;
     let currentDay = 1;
@@ -3603,6 +3608,7 @@ function sanitizeAIText(raw) {
 
                     const isGpt5 = typeof adminConfig.model === 'string' && adminConfig.model.startsWith('gpt-5');
                     const supportsCustomTemp = modelSupportsCustomTemperature(adminConfig.model);
+                    const supportsReasoning = modelSupportsReasoning(adminConfig.model);
                     requestBody = {
                         model: adminConfig.model,
                         systemPrompt,
@@ -3634,7 +3640,7 @@ function sanitizeAIText(raw) {
                     if (Array.isArray(openaiParams.stop) && openaiParams.stop.length) {
                         requestBody.stop = openaiParams.stop;
                     }
-                    if (openaiParams.reasoning_effort) {
+                    if (supportsReasoning && openaiParams.reasoning_effort) {
                         requestBody.reasoning = { effort: openaiParams.reasoning_effort };
                     }
                     if (openaiParams.text_verbosity) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+    "name": "mentalize-system",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "mentalize-system",
+            "version": "1.0.0"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track the latest structured state in the chat UI and reset it when starting or ending sessions
- send the stored state with OpenAI and Claude proxy requests and extract reply/state pairs from the responses
- persist structured state snapshots alongside experiment logs for later inspection

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120b582ba0832bac6ae48957fdecf1)